### PR TITLE
Fix: Parse all rows to find max column count in markdown tables

### DIFF
--- a/gax/formats/markdown.py
+++ b/gax/formats/markdown.py
@@ -14,33 +14,46 @@ class MarkdownFormat(Format):
         if len(lines) < 2:
             return pd.DataFrame()
 
-        # Parse header row
-        headers = [c.strip() for c in lines[0].split("|")]
-        # Remove empty strings from leading/trailing pipes
-        if headers and headers[0] == "":
-            headers = headers[1:]
-        if headers and headers[-1] == "":
-            headers = headers[:-1]
+        # First pass: parse all rows to find maximum column count
+        # This handles files with multiple tables of different widths
+        all_rows = []
+        max_cols = 0
 
-        # Skip separator row (|---|---|)
-        data_start = 1
-        if len(lines) > 1 and re.match(r"^\|?[\s\-:|]+\|?$", lines[1]):
-            data_start = 2
-
-        # Parse data rows
-        rows = []
-        for line in lines[data_start:]:
+        for line in lines:
             if not line.strip():
                 continue
+            # Skip separator rows
+            if re.match(r"^\|?[\s\-:|]+\|?$", line):
+                continue
+
             cells = [c.strip() for c in line.split("|")]
+            # Remove empty strings from leading/trailing pipes
             if cells and cells[0] == "":
                 cells = cells[1:]
             if cells and cells[-1] == "":
                 cells = cells[:-1]
-            # Pad row to match header length
-            while len(cells) < len(headers):
+
+            if cells:  # Only add non-empty rows
+                all_rows.append(cells)
+                max_cols = max(max_cols, len(cells))
+
+        if not all_rows or max_cols == 0:
+            return pd.DataFrame()
+
+        # Use first row as headers
+        headers = all_rows[0]
+
+        # If first row has fewer columns than max, pad headers
+        while len(headers) < max_cols:
+            headers.append("")
+
+        # Process data rows (skip first row which is headers)
+        rows = []
+        for cells in all_rows[1:]:
+            # Pad row to match max column count
+            while len(cells) < max_cols:
                 cells.append("")
-            rows.append(cells[: len(headers)])
+            rows.append(cells[:max_cols])
 
         df = pd.DataFrame(rows, columns=headers)
         df = df.fillna("")

--- a/tests/test_markdown_format.py
+++ b/tests/test_markdown_format.py
@@ -1,0 +1,116 @@
+"""Tests for markdown format handler.
+
+Regression tests for issue #8: sheet push drops columns beyond 5th.
+"""
+
+from gax.formats.markdown import MarkdownFormat
+
+
+class TestMarkdownFormat:
+    """Tests for MarkdownFormat read/write."""
+
+    def test_simple_table(self):
+        """Test parsing a simple markdown table."""
+        content = """| Name | Age | City |
+| --- | --- | --- |
+| Alice | 30 | NYC |
+| Bob | 25 | LA |
+"""
+        fmt = MarkdownFormat()
+        df = fmt.read(content)
+
+        assert df.shape == (2, 3)
+        assert list(df.columns) == ["Name", "Age", "City"]
+        assert df.iloc[0]["Name"] == "Alice"
+        assert df.iloc[1]["City"] == "LA"
+
+    def test_simple_8_column_table(self):
+        """Test parsing an 8-column table (issue #8 regression)."""
+        content = """| Col1 | Col2 | Col3 | Col4 | Col5 | Col6 | Col7 | Col8 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| A | B | C | D | E | F | G | H |
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+"""
+        fmt = MarkdownFormat()
+        df = fmt.read(content)
+
+        assert df.shape == (2, 8), f"Expected (2, 8), got {df.shape}"
+        assert list(df.columns) == [
+            "Col1",
+            "Col2",
+            "Col3",
+            "Col4",
+            "Col5",
+            "Col6",
+            "Col7",
+            "Col8",
+        ]
+
+        # Check first data row
+        assert list(df.iloc[0]) == ["A", "B", "C", "D", "E", "F", "G", "H"]
+
+        # Check second data row
+        assert list(df.iloc[1]) == ["1", "2", "3", "4", "5", "6", "7", "8"]
+
+    def test_variable_width_tables(self):
+        """Test parsing file with tables of different widths (issue #8).
+
+        Simulates Bitcoin tab: 5-column summary table followed by 8-column
+        transaction table. The parser should use the maximum column count.
+        """
+        content = """| ZUSAMMENFASSUNG |  |  |  |  |
+| --- | --- | --- | --- | --- |
+| **Steuerstatus 2025** | **€0 Steuer** | ✅ | Info |  |
+| Verkaufserlöse gesamt | 14.259,77 € | 9 Transaktionen | Jan + Sep 2025 |  |
+| TRANSAKTIONSHISTORIE |  |  |  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Datum | Zeit | Typ | Asset | Menge | EUR | Preis (EUR) | TX-ID |
+| 2021-04-23 | 14:10:42 | BUY | ETH | 0.10232110 | 200.00 | 1954.63 | Tc9a41cb |
+| 2021-04-23 | 14:11:40 | BUY | DOGE | 971.30748137 | 200.00 | 0.21 | Tad6b7a3 |
+"""
+
+        fmt = MarkdownFormat()
+        df = fmt.read(content)
+
+        # Should use maximum column count (8) from the wider table
+        assert df.shape[1] == 8, f"Expected 8 columns, got {df.shape[1]}"
+
+        # Check that all columns from 8-column rows are preserved
+        # The last row should have all 8 values
+        last_row = df.iloc[-1]
+        assert last_row.iloc[0] == "2021-04-23"  # Datum
+        assert last_row.iloc[1] == "14:11:40"  # Zeit
+        assert last_row.iloc[2] == "BUY"  # Typ
+        assert last_row.iloc[3] == "DOGE"  # Asset
+        assert last_row.iloc[4] == "971.30748137"  # Menge
+        assert last_row.iloc[5] == "200.00"  # EUR
+        assert last_row.iloc[6] == "0.21"  # Preis (EUR)
+        assert last_row.iloc[7] == "Tad6b7a3"  # TX-ID
+
+    def test_write_roundtrip(self):
+        """Test that write -> read preserves data."""
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "Col1": ["A", "B"],
+                "Col2": ["C", "D"],
+                "Col3": ["E", "F"],
+            }
+        )
+
+        fmt = MarkdownFormat()
+        content = fmt.write(df)
+        df2 = fmt.read(content)
+
+        assert df.shape == df2.shape
+        assert list(df.columns) == list(df2.columns)
+        assert list(df.iloc[0]) == list(df2.iloc[0])
+
+    def test_empty_content(self):
+        """Test handling empty content."""
+        fmt = MarkdownFormat()
+        df = fmt.read("")
+
+        assert len(df) == 0
+        assert len(df.columns) == 0


### PR DESCRIPTION
## Summary

Fixes #8: `gax sheet push` was silently dropping columns beyond the 5th when pushing markdown tables to Google Sheets.

## Problem

The markdown parser (`MarkdownFormat.read()`) was using only the first row to determine column count, then truncating all subsequent rows to match. This caused data loss when files contained multiple tables of different widths (e.g., a 5-column summary table followed by an 8-column transaction table).

Example: Bitcoin transaction history with 8 columns (Datum, Zeit, Typ, Asset, Menge, EUR, Preis (EUR), TX-ID) would lose the last 3 columns (EUR, Preis, TX-ID) after push.

## Solution

Modified `MarkdownFormat.read()` to:
1. Scan ALL rows in the file (not just the first row)
2. Find the maximum column count across all rows
3. Pad all rows to match the widest row

This ensures no data is lost when tables of different widths appear in the same file.

## Changes

- **gax/formats/markdown.py**: Rewrote `read()` method with two-pass parsing
- **tests/test_markdown_format.py**: Added comprehensive test coverage including:
  - Simple 8-column table test
  - Variable-width tables test (5-column + 8-column in same file)
  - Roundtrip test
  - Edge cases (empty content)

## Test Plan

- [x] All existing gsheet tests pass (14/14)
- [x] New markdown format tests pass (5/5)
- [x] Linting passes
- [x] Manually tested with Bitcoin transaction data

🤖 Generated with [Claude Code](https://claude.com/claude-code)