### PR TITLE
feat: add gax bug command

### DIFF
--- a/gax/cli.py
+++ b/gax/cli.py
@@ -1741,5 +1741,39 @@ main.add_command(contacts)
 main.add_command(gdrive_file, name="file")
 
 
+REPO = "HeinrichHartmann/gax"
+ISSUES_URL = f"https://github.com/{REPO}/issues"
+
+
+@main.command()
+@click.argument("title", required=False)
+@click.option("--body", "-b", help="Bug description")
+def bug(title: str | None, body: str | None):
+    """Report a bug (opens GitHub issue via gh CLI).
+
+    \b
+    Examples:
+        gax bug
+        gax bug "Push swallows newlines"
+        gax bug "Push swallows newlines" -b "When pushing .tab.gax files..."
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("gh"):
+        click.echo("Error: 'gh' (GitHub CLI) is not installed.", err=True)
+        click.echo(f"\nPlease report bugs at: {ISSUES_URL}/new", err=True)
+        click.echo("\nOr install gh: https://cli.github.com/", err=True)
+        sys.exit(1)
+
+    cmd = ["gh", "issue", "create", "--repo", REPO, "--label", "bug"]
+    if title:
+        cmd += ["--title", title]
+    if body:
+        cmd += ["--body", body]
+
+    sys.exit(subprocess.call(cmd))
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Adds `gax bug` command that shells out to `gh issue create` with the `bug` label
- If `gh` is not installed, prints the GitHub issues URL with install instructions

Closes #18 (partially — bug reporting part)

## Test plan
- [x] `gax bug --help` works
- [ ] `gax bug "test"` creates an issue
- [ ] Without `gh` installed, shows fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)