### PR TITLE
Clone fetches single tab only (ADR 026)

### DIFF
--- a/ADR/026-clone-file-checkout-directory.md
+++ b/ADR/026-clone-file-checkout-directory.md
@@ -1,0 +1,153 @@
+# ADR 026: Clone Creates Files, Checkout Creates Directories
+
+**Status:** Proposed
+**Date:** 2026-04-15
+
+Supersedes ADR 019 (Clone vs Checkout Pattern)
+Supersedes ADR 002 (Multipart Markdown Format) for doc/sheet resources
+
+## Context
+
+ADR 019 defined clone as producing a multipart file (all tabs concatenated) and checkout as producing a directory of individual files. In practice, the multipart format has caused problems:
+
+- `content-length` header needed when markdown contains `---`
+- Poor editor experience for large multipart files
+- Users rarely want "all tabs in one file" — they want one tab or all tabs individually
+- The `explode` command exists only to undo the multipart bundling
+
+The core insight: **clone should produce a single resource, checkout should produce a collection**.
+
+## Decision
+
+### Rule
+
+| Command | Output | Scope |
+|---------|--------|-------|
+| `clone` | Single file | One resource (one tab, one thread, one event) |
+| `checkout` | Directory | Collection (all tabs, all threads, all events) |
+
+Clone never produces multipart files. Checkout always produces a directory.
+
+### Doc Clone
+
+`gax doc clone <url>` clones the **first tab only** as a single `.doc.gax` file.
+
+If the document has multiple tabs, print a status message:
+
+```
+✓ Created: Project_Notes.doc.gax
+  Tab "Overview" cloned (1 of 3 tabs).
+  For all tabs: gax doc checkout <url>
+```
+
+If the document has a single tab, no extra message is needed.
+
+### Doc Checkout
+
+`gax doc checkout <url>` — no change from current behavior. Creates a directory with individual `.tab.gax` files and `.gax.yaml` metadata.
+
+```
+Project_Notes.doc.gax.d/
+├── .gax.yaml
+├── Overview.tab.gax
+├── Design.tab.gax
+└── Appendix.tab.gax
+```
+
+### Sheet Clone
+
+`gax sheet clone <url>` clones the **first tab only** as a single `.sheet.gax` file (single-section, no multipart).
+
+If the spreadsheet has multiple tabs, print a status message:
+
+```
+✓ Created: Budget_2026.sheet.gax
+  Tab "Revenue" cloned (1 of 5 tabs).
+  For all tabs: gax sheet checkout <url>
+```
+
+### Sheet Checkout
+
+`gax sheet checkout <url>` — no change from current behavior. Creates a directory with individual `.tab.sheet.gax` files and `.gax.yaml` metadata.
+
+### Top-Level Commands
+
+`gax clone <url>` dispatches to the resource-specific clone (single file).
+`gax checkout <url>` dispatches to the resource-specific checkout (directory).
+
+### Other Resources
+
+| Resource | clone | checkout |
+|----------|-------|----------|
+| doc | First tab → file | All tabs → directory |
+| sheet | First tab → file | All tabs → directory |
+| mail | Single thread → file | N/A (use `mailbox`) |
+| mailbox | Label worksheet → file | `mailbox fetch` (existing) |
+| cal | Events snapshot → file | Events → directory |
+| form | Single form → file | N/A |
+| contacts | Contacts → file | N/A |
+
+Cal and mailbox are out of scope for this ADR — their existing behavior is unchanged.
+
+### Explode Command
+
+`gax explode` is removed. There are no multipart files to explode. Users who have existing multipart files can re-clone (single tab) or checkout (all tabs).
+
+### Quiet Mode
+
+`-q/--quiet` suppresses the multi-tab status message. Useful for scripting.
+
+```bash
+gax doc clone -q <url>   # No "1 of 3 tabs" message
+```
+
+### Tab Selection
+
+To clone a specific tab, use the tab URL (e.g. `...#tab=t.xxx` for docs, `...#gid=123` for sheets). The URL identifies the tab — no extra flag needed.
+
+## Implementation
+
+### Doc Clone Changes (`gdoc.py:clone`)
+
+1. Fetch tab list from Docs API (metadata only, via `get_doc_tabs()`)
+2. Export and extract only the first tab's content
+3. Write as single section via `format_section()`
+4. If tab count > 1, print multi-tab status message with checkout hint
+
+### Sheet Clone Changes (`cli.py:sheet_clone` / `gsheet/clone.py`)
+
+1. Fetch spreadsheet metadata to get tab list and total count
+2. Fetch content for only the first tab
+3. Write as single-section file (no `format_multipart`)
+4. If tab count > 1, print status message with checkout hint
+
+### What Gets Removed
+
+- `format_multipart()` usage in doc clone and sheet clone
+- `explode` command (if implemented)
+- Multipart parsing is kept for backward compatibility with existing `.gax` files and other resources (cal, mailbox) that still use it
+
+## Migration
+
+Existing multipart `.doc.gax` and `.sheet.gax` files continue to work with `pull` and `push`. No forced migration. Users can re-clone (getting a single-tab file) or checkout (getting a directory) at their convenience.
+
+## Consequences
+
+### Positive
+
+1. **No more multipart files** for docs and sheets — simpler format
+2. **Clear mental model** — clone=file, checkout=directory, always
+3. **No explode** — one fewer command to learn
+4. **Better editor experience** — single-tab files are small and focused
+
+### Negative
+
+1. **Clone gives less data** — only first tab, not all tabs
+2. **Users must know about checkout** — the status message guides them
+
+## Related ADRs
+
+- **ADR 002**: Multipart Markdown Format (superseded for doc/sheet)
+- **ADR 019**: Clone vs Checkout Pattern (superseded — clone no longer produces multipart files)
+- **ADR 022**: Simplified CLI Model (deferred — `clone`/`checkout` remain; no `pull` from URLs)
+- **ADR 025**: Directory-Only Collections (deferred — proposed eliminating clone entirely)

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -7,9 +7,9 @@ import click
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .gsheet import pull as gsheet_pull, push as gsheet_push, clone_all, pull_all
+from .gsheet import pull as gsheet_pull, push as gsheet_push, pull_all
 from .gsheet.client import GSheetClient
-from .multipart import format_multipart, parse_multipart
+from .multipart import Section, format_section, format_multipart, parse_multipart
 from .frontmatter import SheetConfig, format_content, parse_content
 from .formats import get_format
 from . import auth
@@ -1445,13 +1445,42 @@ def sheet():
     default="md",
     help="Output format: md, csv, tsv, psv, json, jsonl",
 )
-def sheet_clone(url: str, output: Path | None, fmt: str):
-    """Clone all tabs from a spreadsheet to a multipart .sheet.gax.md file."""
+@click.option(
+    "-q", "--quiet",
+    is_flag=True,
+    help="Suppress multi-tab status message",
+)
+def sheet_clone(url: str, output: Path | None, fmt: str, quiet: bool):
+    """Clone first tab from a spreadsheet to a .sheet.gax.md file.
+
+    For all tabs, use 'gax sheet checkout'.
+    """
     try:
         spreadsheet_id = _extract_spreadsheet_id(url)
         click.echo(f"Fetching spreadsheet: {spreadsheet_id}")
 
-        title, sections = clone_all(spreadsheet_id, url, fmt)
+        client = GSheetClient()
+        info = client.get_spreadsheet_info(spreadsheet_id)
+        title = info["title"]
+        all_tabs = info["tabs"]
+        first_tab = all_tabs[0]
+
+        # Fetch only the first tab
+        formatter = get_format(fmt)
+        df = client.read(spreadsheet_id, first_tab["title"])
+        data = formatter.write(df)
+
+        from .formats import get_content_type
+        section = Section(
+            headers={
+                "type": "gax/sheet",
+                "title": title,
+                "source": url,
+                "tab": first_tab["title"],
+                "content-type": get_content_type(fmt),
+            },
+            content=data,
+        )
 
         if output:
             file_path = output
@@ -1464,12 +1493,18 @@ def sheet_clone(url: str, output: Path | None, fmt: str):
             click.echo(f"Error: File already exists: {file_path}", err=True)
             sys.exit(1)
 
-        content = format_multipart(sections)
+        content = format_section(section.headers, section.content)
         file_path.write_text(content, encoding="utf-8")
 
-        total_rows = sum(len(s.content.strip().split("\n")) - 1 for s in sections)
+        rows = len(data.strip().split("\n")) - 1
         click.echo(f"Created: {file_path}")
-        click.echo(f"Tabs: {len(sections)}, Total rows: {total_rows}")
+        click.echo(f"Rows: {rows}")
+
+        if not quiet and len(all_tabs) > 1:
+            click.echo(
+                f'  Tab "{first_tab["title"]}" cloned (1 of {len(all_tabs)} tabs).\n'
+                f"  For all tabs: gax sheet checkout {url}"
+            )
 
     except Exception as e:
         click.echo(f"Error: {e}", err=True)

--- a/gax/gdoc.py
+++ b/gax/gdoc.py
@@ -1087,26 +1087,61 @@ def _add_comments_to_sections(
     is_flag=True,
     help="Include document comments as separate sections",
 )
-def clone(url: str, output: Optional[Path], with_comments: bool):
-    """Clone a Google Doc to a local .doc.gax.md file."""
+@click.option(
+    "-q", "--quiet",
+    is_flag=True,
+    help="Suppress multi-tab status message",
+)
+def clone(url: str, output: Optional[Path], with_comments: bool, quiet: bool):
+    """Clone a Google Doc to a local .doc.gax.md file.
+
+    Clones a single tab. For multi-tab documents, use 'gax doc checkout'.
+    """
     try:
         document_id = extract_doc_id(url)
         source_url = f"https://docs.google.com/document/d/{document_id}/edit"
 
         click.echo(f"Fetching: {document_id}")
-        sections = pull_doc(document_id, source_url)
+
+        # Fetch tab metadata
+        tabs = native_md.get_doc_tabs(document_id)
+        if not tabs:
+            tabs = [{"id": "", "title": "Document", "index": 0}]
+
+        # Get document title
+        creds = get_authenticated_credentials()
+        docs_service = build("docs", "v1", credentials=creds)
+        doc = docs_service.documents().get(documentId=document_id).execute()
+        doc_title = doc.get("title", "Untitled")
+
+        # Export only the first tab
+        first_tab = tabs[0]
+        full_md = native_md.export_doc_markdown(document_id)
+        tab_titles = [t["title"] for t in tabs]
+        tab_contents = native_md.split_doc_by_tabs(full_md, tab_titles)
+        tab_content = tab_contents.get(first_tab["title"], "")
+
+        time_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        section = DocSection(
+            title=doc_title,
+            source=source_url,
+            time=time_str,
+            section=1,
+            section_title=first_tab["title"],
+            content=tab_content,
+        )
 
         if with_comments:
             click.echo("Fetching comments...")
-            sections = _add_comments_to_sections(sections, document_id)
-
-        content = format_multipart(sections)
+            sections = _add_comments_to_sections([section], document_id)
+            content = format_multipart(sections)
+        else:
+            content = format_section(section)
 
         if output:
             file_path = output
         else:
-            # Generate filename from title
-            safe_name = re.sub(r'[<>:"/\\|?*]', "-", sections[0].title)
+            safe_name = re.sub(r'[<>:"/\\|?*]', "-", doc_title)
             safe_name = re.sub(r"\s+", "_", safe_name)
             file_path = Path(f"{safe_name}.doc.gax.md")
 
@@ -1116,8 +1151,12 @@ def clone(url: str, output: Optional[Path], with_comments: bool):
 
         file_path.write_text(content, encoding="utf-8")
         success(f"Created: {file_path}")
-        click.echo(f"Title: {sections[0].title}")
-        click.echo(f"Sections: {len(sections)}")
+
+        if not quiet and len(tabs) > 1:
+            click.echo(
+                f'  Tab "{first_tab["title"]}" cloned (1 of {len(tabs)} tabs).\n'
+                f"  For all tabs: gax doc checkout {url}"
+            )
 
     except Exception as e:
         error(f"Error: {e}")


### PR DESCRIPTION
## Summary

- Add ADR 026: clone creates files (single tab), checkout creates directories (all tabs)
- Doc clone and sheet clone now fetch only the first tab instead of multipart files
- Multi-tab resources show a status message pointing to `gax doc/sheet checkout`
- Adds `-q/--quiet` flag to suppress the multi-tab hint

## Test plan

- [x] All 184 unit tests pass
- [x] All 32 e2e tests pass (including roundtrip identity)
- [x] Manual test: `gax doc clone` on a multi-tab doc → single tab file + hint
- [x] Manual test: `gax sheet clone` on a multi-tab sheet → single tab file + hint
- [x] Manual test: `-q` flag suppresses hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)