### PR TITLE
feat: gax upgrade + doc push fidelity warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ ENV/
 REVIEW/
 gax/Icon?
 .gax/
+TEST_REPORT.md
+REVIEW.md

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ COMMANDS
 
   Main:
 
-    clone:
-      gax clone [URL]
-          Clone a Google resource from URL.
-          -o, --output: Output file
-          -f, --format: Output format (for forms)
-
     checkout:
       gax checkout [URL]
           Checkout a Google resource from URL into a folder of individual files.
           -o, --output: Output folder
           -f, --format: Output format (for sheets)
+
+    clone:
+      gax clone [URL]
+          Clone a Google resource from URL.
+          -o, --output: Output file
+          -f, --format: Output format (for forms)
 
     pull:
       gax pull [FILES]
@@ -91,120 +91,226 @@ COMMANDS
           List available calendars.
       gax cal checkout [CALENDAR]
           Checkout events as individual .cal.gax.md files into a folder.
+          -o, --output: Output folder (default: calendar.cal.gax.md.d)
+          --days, -d: Number of days (default: 7)
+          --from: Start date (YYYY-MM-DD)
+          --to: End date (YYYY-MM-DD)
       gax cal clone [CALENDAR]
           Clone events to a .cal.gax.md file.
+          -o, --output: Output file (default: calendar.cal.gax.md)
+          --days, -d: Number of days (default: 7)
+          --from: Start date (YYYY-MM-DD)
+          --to: End date (YYYY-MM-DD)
+          -v, --verbose: Include event descriptions
       gax cal event clone [ID_OR_URL]
           Clone an event to a local .cal.gax.md file.
+          --cal, -c: Calendar ID (default: primary)
+          -o, --output: Output file path
+      gax cal event delete [FILE_PATH]
+          Delete event from calendar.
+          -y, --yes: Skip confirmation
+      gax cal event new
+          Create a new event file (edit and push to create upstream).
+          --cal, -c: Calendar ID (default: primary)
+          -o, --output: Output file path
+      gax cal event pull [FILE_PATH]
+          Pull latest event data from API.
       gax cal event push [FILE_PATH]
           Push local changes to API.
+          -y, --yes: Skip confirmation
       gax cal list [CALENDAR]
           List events from a calendar.
+          --days, -d: Number of days to show (default: 7)
+          --from: Start date (YYYY-MM-DD)
+          --to: End date (YYYY-MM-DD)
+          --format, -f: Output format (default: md)
+          -v, --verbose: Include event descriptions
       gax cal pull [FILE]
           Pull latest events to existing file.
 
     contacts [unstable]:
-      gax contacts clone
-          Clone all contacts to a local file.
-      gax contacts plan [FILE]
-          Generate a plan for syncing local contacts to Google.
       gax contacts apply [PLAN_FILE]
           Apply a contacts plan to Google.
+          -y, --yes: Skip confirmation
+      gax contacts clone
+          Clone all contacts to a local file.
+          -f, --format: Output format: md (view-only) or jsonl (editable)
+          -o, --output: Output file (default: contacts.<format>)
+      gax contacts plan [FILE]
+          Generate a plan for syncing local contacts to Google.
+          -o, --output: Output plan file (default: <file>.plan.yaml)
       gax contacts pull [FILE]
           Pull latest contacts from Google.
 
     doc:
-      gax doc clone [URL]
-          Clone a Google Doc to a local .doc.gax.md file.
       gax doc checkout [URL]
           Checkout all tabs to individual files in a folder.
+          -o, --output: Output folder (default: <title>.doc.gax.md.d)
+      gax doc clone [URL]
+          Clone a Google Doc to a local .doc.gax.md file.
+          --output, -o: Output file (default: <title>.doc.gax.md)
+          --with-comments: Include document comments as separate sections
+          -q, --quiet: Suppress multi-tab status message
       gax doc pull [FILE]
           Pull latest content from Google Docs to local file.
+          --with-comments: Include document comments as separate sections
       gax doc tab clone [URL] [TAB_NAME]
           Clone a single tab to a .tab.gax.md file.
-      gax doc tab push [FILE]
-          Push local changes to a single tab.
+          --output, -o: Output file (default: <tab>.tab.gax.md)
       gax doc tab diff [FILE]
           Show diff between local file and remote tab.
+      gax doc tab import [URL] [FILE]
+          Import a markdown file as a new tab in a document.
+          --output, -o: Output tracking file (default: <filename>.tab.gax.md)
+      gax doc tab list [URL]
+          List tabs in a document (TSV output).
+      gax doc tab pull [FILE]
+          Pull latest content for a single tab.
+      gax doc tab push [FILE]
+          Push local changes to a single tab (with confirmation).
+          -y, --yes: Skip confirmation prompt
+          --patch: Incremental push: apply only changed elements (experimental)
 
     draft:
-      gax draft new
-          Create a new local draft file.
       gax draft clone [DRAFT_ID_OR_URL]
           Clone an existing draft from Gmail.
-      gax draft push [FILE]
-          Push local draft to Gmail.
-      gax draft pull [FILE]
-          Pull latest content from Gmail draft.
+          --output, -o: Output file (default: <subject>.draft.gax.md)
       gax draft list
           List Gmail drafts (TSV output).
+          --limit: Maximum results (default: 100)
+      gax draft new
+          Create a new local draft file.
+          --output, -o: Output file (default: <subject>.draft.gax.md)
+          --to: Recipient email address
+          --subject: Email subject
+      gax draft pull [FILE]
+          Pull latest content from Gmail draft.
+      gax draft push [FILE]
+          Push local draft to Gmail.
+          -y, --yes: Skip confirmation prompt
 
     file [unstable]:
       gax file clone [URL_OR_ID]
           Clone a file from Google Drive.
-      gax file push [FILE_PATH]
-          Push local file to Google Drive.
+          -o, --output: Output file path
       gax file pull [FILE_PATH]
           Pull latest version of a file from Google Drive.
+      gax file push [FILE_PATH]
+          Push local file to Google Drive.
+          --public: Make file publicly accessible
+          -y, --yes: Skip confirmation
 
     form [unstable]:
-      gax form clone [URL]
-          Clone a Google Form to a local .form.gax.md file.
-      gax form plan [FILE]
-          Generate a plan from edited form file.
       gax form apply [PLAN_FILE]
           Apply form changes from a plan file.
+          -y, --yes: Skip confirmation
+      gax form clone [URL]
+          Clone a Google Form to a local .form.gax.md file.
+          --output, -o: Output file (default: <title>.form.gax.md)
+          --format, -f: Content format: md (readable, default) or yaml (round-trip safe)
+      gax form plan [FILE]
+          Generate a plan from edited form file.
+          -o, --output: Output plan file
       gax form pull [FILE]
           Pull latest form definition from Google Forms.
 
     mail:
       gax mail clone [THREAD_ID_OR_URL]
           Clone a single email thread to a local .mail.gax.md file.
+          --output, -o: Output file
       gax mail pull [PATH]
           Pull latest messages for .mail.gax.md file(s).
       gax mail reply [FILE_OR_URL]
           Create a reply draft from a thread.
+          --output, -o: Output file (default: Re_<subject>.draft.gax.md)
 
     mail-filter [unstable]:
-      gax mail-filter clone
-          Clone Gmail filters to a .gax.md file.
-      gax mail-filter plan [FILE]
-          Generate plan from edited filters file.
       gax mail-filter apply [PLAN_FILE]
           Apply filter changes from plan file.
+          -y, --yes: Skip confirmation
+      gax mail-filter clone
+          Clone Gmail filters to a .gax.md file.
+          -o, --output: Output file (default: mail-filters.gax.md)
+      gax mail-filter list
+          List Gmail filters (TSV output).
+      gax mail-filter plan [FILE]
+          Generate plan from edited filters file.
+          -o, --output: Output plan file
+      gax mail-filter pull [FILE]
+          Pull latest filters to existing file.
 
     mail-label [unstable]:
-      gax mail-label clone
-          Clone Gmail labels to a .gax.md file.
-      gax mail-label plan [FILE]
-          Generate plan from edited labels file.
       gax mail-label apply [PLAN_FILE]
           Apply label changes from plan file.
+          -y, --yes: Skip confirmation
+      gax mail-label clone
+          Clone Gmail labels to a .gax.md file.
+          -o, --output: Output file (default: mail-labels.gax.md)
+          --all: Include system labels (read-only)
+      gax mail-label list
+          List Gmail labels (TSV output).
+      gax mail-label plan [FILE]
+          Generate plan from edited labels file.
+          -o, --output: Output plan file
+          --delete: Include deletions in plan
+      gax mail-label pull [FILE]
+          Pull latest labels to existing file.
+          --all: Include system labels (read-only)
 
     mailbox:
-      gax mailbox clone
-          Clone threads from Gmail for bulk labeling.
-      gax mailbox fetch
-          Fetch full threads matching query into a folder.
-      gax mailbox plan [FILE]
-          Generate plan from edited list file.
       gax mailbox apply [PLAN_FILE]
           Apply label changes from plan.
+          -y, --yes: Skip confirmation
+      gax mailbox clone
+          Clone threads from Gmail for bulk labeling.
+          -o, --output: Output file (default: mailbox.gax.md)
+          -q, --query: Search query (default: in:inbox)
+          --limit: Maximum threads (default: 50)
+      gax mailbox fetch
+          Fetch full threads matching query into a folder.
+          -o, --output: Output folder (default: mailbox.gax.md.d)
+          -q, --query: Search query (default: in:inbox)
+          --limit: Maximum threads (default: 50)
+      gax mailbox plan [FILE]
+          Generate plan from edited list file.
+          -o, --output: Output file (default: mailbox.plan.yaml)
       gax mailbox pull [FILE]
           Update a .gax.md file by re-fetching from Gmail.
 
     sheet:
-      gax sheet clone [URL]
-          Clone first tab from a spreadsheet to a .sheet.gax.md file.
+      gax sheet apply [FOLDER]
+          Apply planned changes by pushing to Google Sheets.
+          --with-formulas: Interpret formulas (e.g. =SUM(A1:A10))
+          -y, --yes: Skip confirmation
       gax sheet checkout [URL]
           Checkout all tabs to individual files in a folder.
+          -o, --output: Output folder (default: <title>.sheet.gax.md.d)
+          -f, --format: Output format: md, csv, tsv, psv, json, jsonl
+      gax sheet clone [URL]
+          Clone first tab from a spreadsheet to a .sheet.gax.md file.
+          --output, -o: Output file (default: <title>.sheet.gax.md)
+          -f, --format: Output format: md, csv, tsv, psv, json, jsonl
+          -q, --quiet: Suppress multi-tab status message
+      gax sheet plan [FOLDER]
+          Show what changes would be pushed to Google Sheets.
+      gax sheet pull [FILE]
+          Pull latest data for all tabs in a multipart file or checkout folder.
       gax sheet push [FOLDER]
           Push all tabs in a checkout folder to Google Sheets.
-      gax sheet pull [FILE]
-          Pull latest data for all tabs.
+          --with-formulas: Interpret formulas (e.g. =SUM(A1:A10))
+          -y, --yes: Skip confirmation prompt
       gax sheet tab clone [URL] [TAB_NAME]
           Clone a single tab to a .sheet.gax.md file.
+          --output, -o: Output file (default: <tab>.sheet.gax.md)
+          -f, --format: Output format: md, csv, tsv, psv, json, jsonl
+      gax sheet tab list [URL]
+          List tabs in a spreadsheet (TSV output).
+      gax sheet tab pull [FILE]
+          Pull latest data for a single tab.
       gax sheet tab push [FILE]
           Push local data to a single tab.
+          --with-formulas: Interpret formulas (e.g. =SUM(A1:A10))
+          -y, --yes: Skip confirmation prompt
 
   Utility:
 
@@ -217,13 +323,19 @@ COMMANDS
           Show authentication status.
 
     issue:
-      gax issue [TITLE] [--type bug|feature]
-          File a GitHub issue for gax (opens via gh CLI). Defaults to --type bug.
+      gax issue [TITLE]
+          File a GitHub issue for gax (opens via gh CLI).
+          --body, -b: Issue description
+          --type: Issue type (sets the GitHub label)
+
+    upgrade:
+      gax upgrade
+          Upgrade gax to the latest version from GitHub (uv tool install path).
 
 FILES
+    .sheet.gax.md         Spreadsheet data
     .doc.gax.md           Document
     .tab.gax.md           Single document tab
-    .sheet.gax.md         Spreadsheet data
     .mail.gax.md          Email thread
     .draft.gax.md         Email draft
     .cal.gax.md           Calendar event
@@ -231,6 +343,12 @@ FILES
     .gax.md               Mail list (TSV with YAML header)
     .label.mail.gax.md    Gmail labels state
     .filter.mail.gax.md   Gmail filters state
+
+    ~/.config/gax/credentials.json    OAuth credentials
+    ~/.config/gax/token.json          Access token
+
+SEE ALSO
+    gax <command> --help
 ```
 <!-- END GAX MAN -->
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ COMMANDS
       gax auth status
           Show authentication status.
 
-    bug:
-      gax bug [TITLE]
-          Report a bug (opens GitHub issue via gh CLI).
+    issue:
+      gax issue [TITLE] [--type bug|feature]
+          File a GitHub issue for gax (opens via gh CLI). Defaults to --type bug.
 
 FILES
     .doc.gax.md           Document

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -2059,26 +2059,34 @@ ISSUES_URL = f"https://github.com/{REPO}/issues"
 @docs.section("utility")
 @main.command()
 @click.argument("title", required=False)
-@click.option("--body", "-b", help="Bug description")
-def bug(title: str | None, body: str | None):
-    """Report a bug (opens GitHub issue via gh CLI).
+@click.option("--body", "-b", help="Issue description")
+@click.option(
+    "--type",
+    "issue_type",
+    type=click.Choice(["bug", "feature"]),
+    default="bug",
+    show_default=True,
+    help="Issue type (sets the GitHub label)",
+)
+def issue(title: str | None, body: str | None, issue_type: str):
+    """File a GitHub issue for gax (opens via gh CLI).
 
     \b
     Examples:
-        gax bug
-        gax bug "Push swallows newlines"
-        gax bug "Push swallows newlines" -b "When pushing .tab.gax files..."
+        gax issue
+        gax issue "Push swallows newlines"
+        gax issue "Attachment support" --type feature
     """
     import shutil
     import subprocess
 
     if not shutil.which("gh"):
         click.echo("Error: 'gh' (GitHub CLI) is not installed.", err=True)
-        click.echo(f"\nPlease report bugs at: {ISSUES_URL}/new", err=True)
+        click.echo(f"\nPlease file issues at: {ISSUES_URL}/new", err=True)
         click.echo("\nOr install gh: https://cli.github.com/", err=True)
         sys.exit(1)
 
-    cmd = ["gh", "issue", "create", "--repo", REPO, "--label", "bug"]
+    cmd = ["gh", "issue", "create", "--repo", REPO, "--label", issue_type]
     if title:
         cmd += ["--title", title]
     if body:

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -2087,5 +2087,52 @@ def bug(title: str | None, body: str | None):
     sys.exit(subprocess.call(cmd))
 
 
+@docs.section("utility")
+@main.command()
+def upgrade():
+    """Upgrade gax to the latest version from GitHub (uv tool install path).
+
+    Runs ``uv tool install --reinstall git+<repo>`` so the tool is rebuilt
+    from the current ``main``, then prints the CHANGELOG so you can see
+    what landed.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("uv"):
+        click.echo("Error: 'uv' is not installed.", err=True)
+        click.echo(
+            "Install it: https://docs.astral.sh/uv/getting-started/installation/",
+            err=True,
+        )
+        sys.exit(1)
+
+    git_url = f"git+https://github.com/{REPO}.git"
+    cmd = ["uv", "tool", "install", "--reinstall", git_url]
+    click.echo(f"Running: {' '.join(cmd)}")
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        sys.exit(rc)
+
+    # Fetch CHANGELOG from GitHub (the installed package doesn't ship it)
+    changelog_url = f"https://raw.githubusercontent.com/{REPO}/main/CHANGELOG.md"
+    try:
+        import urllib.request
+        with urllib.request.urlopen(changelog_url, timeout=10) as resp:
+            changelog = resp.read().decode("utf-8")
+    except Exception:
+        changelog = None
+
+    if changelog:
+        click.echo("\n" + "=" * 60)
+        click.echo("CHANGELOG")
+        click.echo("=" * 60)
+        click.echo(changelog)
+    else:
+        click.echo(
+            f"\nView changelog at: https://github.com/{REPO}/blob/main/CHANGELOG.md"
+        )
+
+
 if __name__ == "__main__":
     main()

--- a/gax/gdoc.py
+++ b/gax/gdoc.py
@@ -1068,6 +1068,13 @@ def tab_push(file: Path, yes: bool, use_patch: bool):
             for w in push_warnings:
                 click.echo(f"  Warning: {w.feature}: {w.detail}")
 
+            click.echo(
+                "Warning: markdown cannot faithfully represent a Google Doc. "
+                "Non-markdown formatting (colors, fonts, alignment, comments, "
+                "suggestions, images) may be lost. Use --patch for incremental "
+                "updates that preserve formatting (experimental)."
+            )
+
             if not yes:
                 if not click.confirm("Push these changes?"):
                     click.echo("Aborted.")

--- a/man/gax.1
+++ b/man/gax.1
@@ -144,7 +144,8 @@ Pull latest content for a single tab.
 .TP
 \f[B]gax doc tab push\f[R] \f[I][FILE]\f[R]
 Push local changes to a single tab (with confirmation).
-\f[B]\-y, \[en]yes\f[R]: Skip confirmation prompt
+\f[B]\-y, \[en]yes\f[R]: Skip confirmation prompt \f[B]\[en]patch\f[R]:
+Incremental push: apply only changed elements (experimental)
 .SS draft
 .TP
 \f[B]gax draft clone\f[R] \f[I][DRAFT_ID_OR_URL]\f[R]
@@ -343,8 +344,12 @@ Show authentication status.
 .TP
 \f[B]gax issue\f[R] \f[I][TITLE]\f[R]
 File a GitHub issue for gax (opens via gh CLI).
-\f[B]\[en]body, \-b\f[R]: Issue description.
-\f[B]\[en]type\f[R]: \f[I]bug\f[R] (default) or \f[I]feature\f[R].
+\f[B]\[en]body, \-b\f[R]: Issue description \f[B]\[en]type\f[R]: Issue
+type (sets the GitHub label)
+.SS upgrade
+.TP
+\f[B]gax upgrade\f[R]
+Upgrade gax to the latest version from GitHub (uv tool install path).
 .SH FILES
 .PP
 .TS

--- a/man/gax.1
+++ b/man/gax.1
@@ -339,11 +339,12 @@ Remove stored authentication token.
 .TP
 \f[B]gax auth status\f[R]
 Show authentication status.
-.SS bug
+.SS issue
 .TP
-\f[B]gax bug\f[R] \f[I][TITLE]\f[R]
-Report a bug (opens GitHub issue via gh CLI).
-\f[B]\[en]body, \-b\f[R]: Bug description
+\f[B]gax issue\f[R] \f[I][TITLE]\f[R]
+File a GitHub issue for gax (opens via gh CLI).
+\f[B]\[en]body, \-b\f[R]: Issue description.
+\f[B]\[en]type\f[R]: \f[I]bug\f[R] (default) or \f[I]feature\f[R].
 .SH FILES
 .PP
 .TS

--- a/tests/MANUAL_TEST_PROTOCOL.md
+++ b/tests/MANUAL_TEST_PROTOCOL.md
@@ -2,9 +2,11 @@
 
 ## Instructions (for agents running this protocol)
 
+**This is a strict checklist. Execute it exactly as written. Do not improvise, do not add extra tests, do not skip items, do not substitute your own judgment for what should be tested. If a step is unclear, note it in Other findings and move on -- do not invent an alternative.**
+
 1. **Write your run to `TEST_REPORT.md`** in the repo root. This file is gitignored and clobbered on each run -- do not edit this protocol file itself.
 2. **Copy the checklist** from this file into `TEST_REPORT.md` as your working document.
-3. **Run each test** in order. Execute the exact commands shown.
+3. **Run each test** in order. Execute the exact commands shown -- no variations.
 4. **Validate the result carefully** -- don't just check the exit code. Open files, inspect contents, verify against the Google UI where the test says so. A command that "ran" but produced garbage is a failure.
 5. **Check the box** (`[x]`) in `TEST_REPORT.md` only if the test passed its validation.
 6. **Leave the box unchecked and add a note** directly under the test item if it failed or was skipped. Include the error, exit code, or what was wrong with the output.
@@ -66,9 +68,9 @@ Later this should be converted into an automated smoke test.
 
 ## Mailbox
 
-- [ ] `gax mailbox clone -q "in:inbox" -l 10` -- creates list file
+- [ ] `gax mailbox clone -q "in:inbox" --limit 10` -- creates list file
 - [ ] `gax mailbox pull <file>` -- refreshes
-- [ ] `gax mailbox fetch -q "in:inbox" -l 3 -o threads/` -- materializes full threads
+- [ ] `gax mailbox fetch -q "in:inbox" --limit 3 -o threads/` -- materializes full threads
 
 ## Mail labels
 

--- a/tests/MANUAL_TEST_PROTOCOL.md
+++ b/tests/MANUAL_TEST_PROTOCOL.md
@@ -1,0 +1,115 @@
+# Manual Testing Protocol
+
+## Instructions (for agents running this protocol)
+
+1. **Write your run to `TEST_REPORT.md`** in the repo root. This file is gitignored and clobbered on each run -- do not edit this protocol file itself.
+2. **Copy the checklist** from this file into `TEST_REPORT.md` as your working document.
+3. **Run each test** in order. Execute the exact commands shown.
+4. **Validate the result carefully** -- don't just check the exit code. Open files, inspect contents, verify against the Google UI where the test says so. A command that "ran" but produced garbage is a failure.
+5. **Check the box** (`[x]`) in `TEST_REPORT.md` only if the test passed its validation.
+6. **Leave the box unchecked and add a note** directly under the test item if it failed or was skipped. Include the error, exit code, or what was wrong with the output.
+7. **Record "other findings"** in the dedicated section: warnings that appeared, surprising output, UX quirks, performance issues, anything a human should know even if the test "passed".
+8. **Write the final report** at the bottom of `TEST_REPORT.md` using this structure:
+
+   ```
+   ## Report
+
+   18/20 checks passed
+
+   Failed checks:
+   - <section>: <test description> -- <what went wrong>
+   - ...
+
+   Other findings:
+   - ...
+   ```
+
+   If all checks passed, write `20/20 checks passed` and omit the "Failed checks" block.
+
+## Scope
+
+gax does not yet have full automated test coverage. This checklist exercises
+the advertised read paths before a release, using whatever Google account is
+already configured. Push paths are only touched superficially. Unified
+commands and unstable features are excluded from baseline testing.
+
+Later this should be converted into an automated smoke test.
+
+## Setup
+
+- [ ] `gax auth status` -- shows authenticated
+- [ ] Scratch directory: `mkdir /tmp/gax-smoke && cd /tmp/gax-smoke`
+- [ ] Pick existing resources from your own account:
+  - A Google Doc with 2+ tabs (`DOC_URL`)
+  - A Google Sheet with 2+ tabs (`SHEET_URL`)
+  - A recent email thread (`THREAD_URL`)
+  - An existing Gmail draft (`DRAFT_URL`)
+
+## Help & manual
+
+- [ ] `gax --version` -- prints version
+- [ ] `gax --help` -- lists commands
+- [ ] `gax man` -- prints manual
+
+## Mail
+
+- [ ] `gax mail clone THREAD_URL` -- creates `.mail.gax.md`, attachments saved to `~/.gax/store/`
+- [ ] `gax mail pull <file>` -- refreshes, no errors
+- [ ] `gax mail reply <file>` -- creates a `.draft.gax.md` file (don't send)
+
+## Drafts
+
+- [ ] `gax draft list` -- TSV listing of drafts
+- [ ] `gax draft clone DRAFT_URL` -- clones existing draft
+- [ ] `gax draft pull <file>` -- refreshes, no errors
+- [ ] Push (light): `gax draft new`, fill to/subject/body, `gax draft push <file>`, verify draft appears in Gmail, delete
+
+## Mailbox
+
+- [ ] `gax mailbox clone -q "in:inbox" -l 10` -- creates list file
+- [ ] `gax mailbox pull <file>` -- refreshes
+- [ ] `gax mailbox fetch -q "in:inbox" -l 3 -o threads/` -- materializes full threads
+
+## Mail labels
+
+- [ ] `gax mail-label clone` -- creates `label.mail.gax.md` snapshot of current labels
+- [ ] `gax mail-label plan <file>` -- shows plan with no changes
+
+## Mail filters
+
+- [ ] `gax mail-filter clone` -- creates `filter.mail.gax.md` snapshot of current filters
+- [ ] `gax mail-filter plan <file>` -- shows plan with no changes
+
+## Calendar
+
+- [ ] `gax cal calendars` -- lists calendars
+- [ ] `gax cal clone primary` -- creates `primary.cal.gax.md` with events
+
+## Error handling
+
+- [ ] `gax doc clone https://docs.google.com/document/d/NONEXISTENT/edit` -- readable error, non-zero exit
+- [ ] `gax pull nonexistent.gax.md` -- readable error
+
+## Unstable / lower priority
+
+Exercise only when changes touch these areas.
+
+### Forms
+
+- [ ] `gax form clone FORM_URL` -- clone form definition
+- [ ] `gax form pull <file>` -- refresh
+
+### Contacts
+
+- [ ] `gax contacts clone` -- clone all contacts
+- [ ] `gax contacts pull <file>` -- refresh
+
+### Drive files
+
+- [ ] `gax file clone DRIVE_FILE_URL` -- download file + tracking `.gax.md`
+- [ ] `gax file pull <file>` -- refresh
+
+## Cleanup
+
+- [ ] Remove any drafts/files created during testing
+- [ ] `rm -rf /tmp/gax-smoke`


### PR DESCRIPTION
## Summary
- Closes #25: `gax upgrade` runs `uv tool install --reinstall git+<repo>` and prints `CHANGELOG.md` fetched from GitHub.
- Closes #27: `gax doc tab push` (default, non-`--patch` path) now prints a blanket warning that markdown can't faithfully represent a Google Doc, pointing to `--patch` as the formatting-preserving alternative.

## Test plan
- [ ] `gax upgrade` runs on a uv-installed gax and shows the CHANGELOG
- [ ] `gax doc tab push <file>` (without `--patch`) shows the new warning before the confirm prompt
- [ ] `gax doc tab push <file> --patch` is unchanged