### PR TITLE
fix: draft list crash, cal clone primary, pull exit code

### DIFF
--- a/gax/cli.py
+++ b/gax/cli.py
@@ -1040,6 +1040,9 @@ def unified_pull(files: tuple[str, ...], verbose: bool):
         else:
             ui_success(summary)
 
+    if fail_count:
+        sys.exit(1)
+
 
 @docs.section("main")
 @main.command("push")

--- a/gax/draft.py
+++ b/gax/draft.py
@@ -310,7 +310,6 @@ def get_draft_summary(draft_id: str, *, service=None) -> dict:
             userId="me",
             id=draft_id,
             format="metadata",
-            metadataHeaders=["To", "Subject", "Date"],
         )
         .execute()
     )

--- a/gax/gcal.py
+++ b/gax/gcal.py
@@ -672,7 +672,7 @@ def _resolve_calendar_id(calendar: str | None) -> str:
 
     Returns "primary" if calendar is None.
     """
-    if not calendar:
+    if not calendar or calendar == "primary":
         return "primary"
 
     calendars = list_calendars()


### PR DESCRIPTION
## Summary

Three bugs found during manual smoke testing against GitHub main:

- **`gax draft list` crash**: removed invalid `metadataHeaders` kwarg from Gmail API `.drafts().get()` call — the parameter isn't accepted by the Python client; `format="metadata"` already returns all headers
- **`gax cal clone primary` failure**: `_resolve_calendar_id` was doing a name lookup even for the literal string `"primary"`, which the API accepts as a special alias — now passed through directly
- **`gax pull nonexistent.gax.md` exit 0**: pull command was printing an error but exiting 0 on missing/failed files — now exits 1

## Test plan

- [ ] `gax draft list` returns TSV without error
- [ ] `gax cal clone primary` clones primary calendar events
- [ ] `gax pull nonexistent.gax.md` exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)