### PR TITLE
feat: Google Drive folder checkout and pull

### DIFF
--- a/ADR/028-drive-folder-sync.md
+++ b/ADR/028-drive-folder-sync.md
@@ -1,0 +1,167 @@
+# ADR 028: Google Drive Folder Sync
+
+## Status
+
+Proposed
+
+## Context
+
+gax supports single-file Google Drive operations via `gax file clone/pull/push` — download a file, track it with a sidecar `.gax.md` file, and push changes back. There is no way to sync an entire Drive folder.
+
+Teams use shared Drive folders as document repositories. Being able to clone a folder locally enables:
+
+- Bidirectional sync of shared project assets
+- LLM agents reading and modifying folder contents through local files
+- Offline access with tracked provenance
+
+Other gax resources already have folder checkout patterns: Sheet creates `.sheet.gax.md.d/` folders with per-tab files, Doc creates `.doc.gax.md.d/` folders. Drive folder sync follows the same pattern.
+
+## Decision
+
+### Folder checkout model
+
+A Drive folder becomes a local directory with the suffix `.drive.gax.md.d/`. Each file in the folder keeps a per-file sidecar (the existing `.gax.md` tracking file pattern). A `.gax.yaml` metadata file at the root tracks the Drive folder ID.
+
+```
+Project_Assets.drive.gax.md.d/
+├── .gax.yaml                      # folder metadata
+├── logo.png                       # actual file
+├── logo.png.gax.md                # sidecar (file_id, size, etc.)
+├── budget.xlsx
+├── budget.xlsx.gax.md
+└── notes/                         # subfolder (recursive)
+    ├── meeting.pdf
+    ├── meeting.pdf.gax.md
+    └── ideas.txt
+    └── ideas.txt.gax.md
+```
+
+### .gax.yaml format
+
+```yaml
+type: gax/drive-checkout
+folder_id: 1AbCdEfGhIjKlMnOpQrStUvWxYz
+url: https://drive.google.com/drive/folders/1AbCdEfGhIjKlMnOpQrStUvWxYz
+title: Project Assets
+recursive: false           # true if checked out with -R
+checked_out: 2026-04-18T10:00:00Z
+```
+
+### Resource classes
+
+Following the dual-class pattern (File/Folder like SheetTab/Sheet, Event/Cal):
+
+- **`File(Resource)`** — already exists. Single file. Unchanged.
+- **`Folder`** — new class. Not a Resource subclass (collection manager, like Mailbox and Sheet). Methods: `checkout`, `pull`, `diff`, `push`.
+
+### Operations
+
+**Checkout** (`gax file checkout <folder-url> [-R]`):
+1. Extract folder ID, fetch folder name
+2. Create `<name>.drive.gax.md.d/`, write `.gax.yaml`
+3. List files in folder (flat by default, recursive with `-R`)
+4. Download each file + create sidecar
+5. With `-R`: create local subdirectories for Drive subfolders
+6. Skip files that already exist locally (incremental)
+
+**Pull** (`gax pull folder.drive.gax.md.d`):
+1. List remote folder contents
+2. Compare against local sidecars
+3. Download new files, refresh changed files
+4. Report additions/deletions
+
+**Diff** (`gax file diff folder.drive.gax.md.d`):
+Compare local folder structure against remote. Report new remote files, deleted files, size/timestamp changes, new local files (no sidecar).
+
+**Push** (`gax push folder.drive.gax.md.d`):
+1. Walk local tree
+2. Files with sidecar → update on Drive if changed
+3. Files without sidecar → upload as new to Drive folder
+4. Show plan, confirm, execute
+
+### API additions
+
+```python
+def extract_folder_id(url_or_id: str) -> str:
+    """Extract folder ID from Drive folder URL."""
+
+def list_folder(folder_id: str, *, recursive: bool = True) -> list[dict]:
+    """List files in a Drive folder.
+    
+    Returns flat list of dicts, each with:
+      id, name, mimeType, size, path (relative), is_folder
+    Handles pagination internally.
+    """
+```
+
+### CLI commands
+
+```
+gax file checkout <folder-url> [-o FOLDER] [-R]   # new command
+gax pull <folder>.drive.gax.md.d                   # works via unified pull
+gax push <folder>.drive.gax.md.d                   # works via unified push
+```
+
+`-R` enables recursive traversal of subfolders. Without it, only files directly in the folder are cloned. The flag is recorded in `.gax.yaml` so subsequent `pull` operations respect the original depth.
+
+The unified `gax pull`/`gax push` dispatch in `cli_helper.py` gains a `gax/drive-checkout` case.
+
+### Google Workspace files
+
+When a file in the Drive folder is a Google Workspace type, clone it using the native gax resource instead of binary download:
+
+| Drive MIME type | gax resource | Local file |
+|----------------|-------------|------------|
+| `application/vnd.google-apps.document` | `Doc().clone()` | `<name>.doc.gax.md` |
+| `application/vnd.google-apps.spreadsheet` | `SheetTab().clone()` | `<name>.sheet.gax.md` |
+| `application/vnd.google-apps.form` | `Form().clone()` | `<name>.form.gax.md` |
+| `application/vnd.google-apps.presentation` | skip + warning | — |
+| everything else | `File().clone()` | `<name>.<ext>` + sidecar |
+
+This means a checkout folder can contain a mix of binary files (with sidecars) and gax resource files (self-tracking, no sidecar needed). Pull/push dispatches per-file based on extension, same as the unified `gax pull` already does.
+
+## Edge cases
+
+**Filename conflicts**: Drive allows duplicate filenames in the same folder; local filesystems do not. Resolve by appending `_<id[:8]>` suffix to the second file.
+
+**Large folders**: Use progress spinner. Consider a `--limit` flag for initial testing.
+
+**Permissions**: Shared folders may contain files the user cannot download. Catch errors per-file and continue.
+
+## Consequences
+
+### Positive
+
+- Enables full folder sync for Drive, completing gax's coverage of Google Workspace
+- Per-file sidecars allow individual file operations (`gax file push report.pdf`) within a checked-out folder
+- Follows established checkout patterns (Sheet, Doc) — no new concepts for users to learn
+
+### Negative
+
+- Sidecar files double the file count in the local tree (each file gets a `.gax.md` companion)
+- Recursive folder listing requires multiple API calls (one per subfolder)
+- Binary files cannot be meaningfully diffed — diff is structural only (new/deleted/size changes)
+
+### Neutral
+
+- Google Workspace files in the folder are cloned via their native gax resource — the checkout folder becomes a mixed tree of binary files (with sidecars) and gax resource files (self-tracking)
+
+## Alternatives considered
+
+### 1. Manifest-only tracking (no per-file sidecars)
+
+Store all file IDs in `.gax.yaml` as a files list. Cleaner local tree but breaks the established File pattern — can't use `gax file push` on individual files within the folder.
+
+**Rejected**: Consistency with existing File resource is more valuable than a cleaner directory listing.
+
+### 2. Recursive by default
+
+Always recurse into subfolders. Matches user expectations for "clone everything."
+
+**Rejected**: Flat by default is safer — avoids accidentally downloading large nested trees. Users opt in to recursion with `-R`.
+
+### 3. Export Workspace files as PDF/docx
+
+When encountering a Google Doc or Sheet in a Drive folder, export it as PDF or docx.
+
+**Rejected**: gax already has native resource handlers for these types. Using them produces editable, round-trippable files instead of static exports.

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -1110,6 +1110,37 @@ def file_clone(url_or_id, output):
         sys.exit(1)
 
 
+@file_group.command("checkout")
+@click.argument("url_or_id")
+@click.option(
+    "-o", "--output", type=click.Path(path_type=Path), help="Output folder path"
+)
+@click.option("-R", "--recursive", is_flag=True, help="Recurse into subfolders")
+def file_checkout(url_or_id, output, recursive):
+    """Checkout a Google Drive folder to a local directory.
+
+    Downloads all files. Google Workspace files (Docs, Sheets, Forms)
+    are cloned via their native gax resource.
+
+    \b
+    Examples:
+        gax file checkout https://drive.google.com/drive/folders/abc123
+        gax file checkout abc123 -o my_folder
+        gax file checkout abc123 -R
+    """
+    try:
+        from .ui import success
+        from .gdrive import Folder
+
+        folder_path = Folder().checkout(url_or_id, output=output, recursive=recursive)
+        success(f"Checked out: {folder_path}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
 @file_group.command("pull")
 @click.argument("file_path", type=click.Path(exists=True, path_type=Path))
 def file_pull(file_path):

--- a/gax/cli_helper.py
+++ b/gax/cli_helper.py
@@ -168,6 +168,16 @@ def _pull_folder(
             from .gdoc import Doc
 
             Doc().clone(url, output=scratch_path)
+
+        elif checkout_type == "gax/drive-checkout":
+            # Drive folders pull in-place (no scratch dir diffing for binary files)
+            if scratch_path.exists():
+                shutil.rmtree(scratch_path)
+            from .gdrive import Folder
+
+            Folder().pull(folder_path)
+            return True, "updated"
+
         else:
             return False, f"Unsupported checkout type: {checkout_type}"
 

--- a/gax/gdrive.py
+++ b/gax/gdrive.py
@@ -388,6 +388,12 @@ class File(Resource):
         logger.info(f"View: {metadata.get('webViewLink', '')}")
 
 
+def _safe_name(name: str) -> str:
+    """Sanitize a file/folder name for use as a local path component."""
+    safe = re.sub(r'[<>:"/\\|?*]', "-", name)
+    return re.sub(r"\s+", "_", safe)
+
+
 # =============================================================================
 # Folder — collection manager for Drive folders (checkout/pull).
 # =============================================================================
@@ -421,9 +427,7 @@ class Folder:
         if output:
             folder = output
         else:
-            safe = re.sub(r'[<>:"/\\|?*]', "-", title)
-            safe = re.sub(r"\s+", "_", safe)
-            folder = Path(f"{safe}.drive.gax.md.d")
+            folder = Path(f"{_safe_name(title)}.drive.gax.md.d")
 
         folder.mkdir(parents=True, exist_ok=True)
 
@@ -517,16 +521,7 @@ class Folder:
         # Pull existing tracked files
         updated = 0
         for sidecar in path.rglob("*.gax.md"):
-            if sidecar.name == ".gax.yaml":
-                continue
-            # Skip gax resource files (they have their own pull)
-            if not sidecar.name.endswith(".gax.md"):
-                continue
-            # Sidecar → actual file
-            name = sidecar.name
-            if not name.endswith(".gax.md"):
-                continue
-            actual = sidecar.parent / name[:-7]  # strip .gax.md
+            actual = sidecar.parent / sidecar.name[:-7]  # strip .gax.md
             if actual.exists():
                 try:
                     File().pull(actual)
@@ -580,7 +575,22 @@ class Folder:
                 sort_keys=False,
             )
 
-        logger.info(f"Updated: {updated}, New: {new_files}")
+        # Report remotely deleted files
+        local_sidecars = set()
+        for sidecar in path.rglob("*.gax.md"):
+            rel = sidecar.parent / sidecar.name[:-7]  # strip .gax.md
+            try:
+                local_sidecars.add(str(rel.relative_to(path)))
+            except ValueError:
+                continue
+        remote_paths = set(remote_by_path.keys())
+        deleted = local_sidecars - remote_paths
+        for d in sorted(deleted):
+            logger.info(f"Deleted remotely: {d}")
+
+        logger.info(
+            f"Updated: {updated}, New: {new_files}, Deleted remotely: {len(deleted)}"
+        )
 
     def _clone_workspace_file(self, item: dict, folder: Path) -> None:
         """Clone a Google Workspace file using its native gax resource."""
@@ -591,8 +601,7 @@ class Folder:
         target_dir = folder / parent if parent else folder
 
         url = f"https://docs.google.com/{_workspace_url_path(resource_type)}/d/{file_id}/edit"
-        safe_name = re.sub(r'[<>:"/\\|?*]', "-", item["name"])
-        safe_name = re.sub(r"\s+", "_", safe_name)
+        safe_name = _safe_name(item["name"])
 
         if resource_type == "doc":
             from .gdoc.doc import Tab
@@ -627,8 +636,7 @@ def _workspace_file_exists(folder: Path, item: dict) -> bool:
     """Check if a Workspace file was already cloned as a .gax.md file."""
     mime = item["mimeType"]
     resource_type = WORKSPACE_MIME_TYPES.get(mime, "")
-    safe_name = re.sub(r'[<>:"/\\|?*]', "-", item["name"])
-    safe_name = re.sub(r"\s+", "_", safe_name)
+    safe_name = _safe_name(item["name"])
     parent = item["path"].rsplit("/", 1)[0] if "/" in item["path"] else ""
     target_dir = folder / parent if parent else folder
 

--- a/gax/gdrive.py
+++ b/gax/gdrive.py
@@ -1,4 +1,4 @@
-"""Google Drive file operations for gax.
+"""Google Drive file and folder operations for gax.
 
 Resource module — follows the draft.py reference pattern.
 
@@ -9,8 +9,9 @@ Module structure
 ================
 
   File format        — create/read sidecar tracking files
-  Drive API helpers  — download, upload, update, permissions
-  File(Resource)     — resource class (the public interface for cli.py)
+  Drive API helpers  — download, upload, update, permissions, folder listing
+  File(Resource)     — single file resource (clone/pull/push)
+  Folder             — folder collection manager (checkout/pull)
 
 Design decisions
 ================
@@ -25,6 +26,11 @@ Additional notes specific to file:
 
   No diff: binary files can't be meaningfully diffed. diff() raises
   NotImplementedError (inherited from base class).
+
+  Folder checkout: creates a .drive.gax.md.d/ directory with per-file
+  sidecars. Google Workspace files (Docs, Sheets, Forms) are cloned
+  via their native gax resource instead of binary download.
+  See ADR 028 for design details.
 """
 
 import logging
@@ -220,7 +226,90 @@ def set_public(file_id: str, public: bool = True):
 
 
 # =============================================================================
-# Resource class — the public interface for cli.py.
+# Folder API helpers — list folder contents, extract folder ID.
+# =============================================================================
+
+WORKSPACE_MIME_TYPES = {
+    "application/vnd.google-apps.document": "doc",
+    "application/vnd.google-apps.spreadsheet": "sheet",
+    "application/vnd.google-apps.form": "form",
+}
+
+FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+
+def extract_folder_id(url_or_id: str) -> str:
+    """Extract folder ID from Google Drive folder URL or return as-is."""
+    patterns = [
+        r"/folders/([a-zA-Z0-9_-]+)",
+        r"^([a-zA-Z0-9_-]+)$",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url_or_id)
+        if match:
+            return match.group(1)
+    raise ValueError(f"Cannot extract folder ID from: {url_or_id}")
+
+
+def get_folder_metadata(folder_id: str, *, service=None) -> dict:
+    """Get folder name and metadata. Returns dict with id, name."""
+    if service is None:
+        creds = get_authenticated_credentials()
+        service = build("drive", "v3", credentials=creds)
+    return service.files().get(fileId=folder_id, fields="id,name").execute()
+
+
+def list_folder(folder_id: str, *, recursive: bool = False, service=None) -> list[dict]:
+    """List files in a Drive folder.
+
+    Returns flat list of dicts, each with:
+      id, name, mimeType, size, path (relative to root folder), is_folder
+
+    Handles pagination. With recursive=True, traverses subfolders.
+    """
+    if service is None:
+        creds = get_authenticated_credentials()
+        service = build("drive", "v3", credentials=creds)
+
+    def _list_one(parent_id: str, prefix: str) -> list[dict]:
+        items = []
+        page_token = None
+        while True:
+            resp = (
+                service.files()
+                .list(
+                    q=f"'{parent_id}' in parents and trashed=false",
+                    fields="nextPageToken,files(id,name,mimeType,size)",
+                    pageSize=1000,
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for f in resp.get("files", []):
+                rel_path = f"{prefix}{f['name']}" if prefix else f["name"]
+                is_folder = f["mimeType"] == FOLDER_MIME_TYPE
+                items.append(
+                    {
+                        "id": f["id"],
+                        "name": f["name"],
+                        "mimeType": f["mimeType"],
+                        "size": int(f.get("size", 0)),
+                        "path": rel_path,
+                        "is_folder": is_folder,
+                    }
+                )
+                if is_folder and recursive:
+                    items.extend(_list_one(f["id"], f"{rel_path}/"))
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+        return items
+
+    return _list_one(folder_id, "")
+
+
+# =============================================================================
+# File(Resource) — single file resource.
 # =============================================================================
 
 
@@ -297,3 +386,252 @@ class File(Resource):
 
         create_tracking_file(path, metadata)
         logger.info(f"View: {metadata.get('webViewLink', '')}")
+
+
+# =============================================================================
+# Folder — collection manager for Drive folders (checkout/pull).
+# =============================================================================
+
+
+class Folder:
+    """Google Drive folder — checkout/pull a folder tree.
+
+    Not a Resource subclass (collection manager, like Mailbox and Sheet).
+    Dispatches to native gax resources for Google Workspace files.
+    """
+
+    name = "folder"
+
+    def checkout(
+        self,
+        url: str,
+        output: Path | None = None,
+        *,
+        recursive: bool = False,
+    ) -> Path:
+        """Checkout a Drive folder to a local directory. Returns path created.
+
+        Downloads all files. Google Workspace files (Docs, Sheets, Forms)
+        are cloned via their native gax resource.
+        """
+        folder_id = extract_folder_id(url)
+        meta = get_folder_metadata(folder_id)
+        title = meta["name"]
+
+        if output:
+            folder = output
+        else:
+            safe = re.sub(r'[<>:"/\\|?*]', "-", title)
+            safe = re.sub(r"\s+", "_", safe)
+            folder = Path(f"{safe}.drive.gax.md.d")
+
+        folder.mkdir(parents=True, exist_ok=True)
+
+        # Write .gax.yaml metadata
+        metadata = {
+            "type": "gax/drive-checkout",
+            "folder_id": folder_id,
+            "url": f"https://drive.google.com/drive/folders/{folder_id}",
+            "title": title,
+            "recursive": recursive,
+            "checked_out": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        with open(folder / ".gax.yaml", "w") as f:
+            yaml.dump(
+                metadata,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+
+        # List and download files
+        items = list_folder(folder_id, recursive=recursive)
+
+        cloned = 0
+        skipped = 0
+
+        for item in items:
+            if item["is_folder"]:
+                # Create local subdirectory
+                (folder / item["path"]).mkdir(parents=True, exist_ok=True)
+                continue
+
+            local_path = folder / item["path"]
+            mime = item["mimeType"]
+
+            # Skip if already exists
+            if local_path.exists() or (
+                mime in WORKSPACE_MIME_TYPES and _workspace_file_exists(folder, item)
+            ):
+                skipped += 1
+                continue
+
+            # Ensure parent dir exists
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+
+            logger.info(f"Cloning: {item['path']}")
+
+            if mime in WORKSPACE_MIME_TYPES:
+                self._clone_workspace_file(item, folder)
+            else:
+                download_file(item["id"], local_path)
+                create_tracking_file(
+                    local_path,
+                    {
+                        "id": item["id"],
+                        "name": item["name"],
+                        "mimeType": mime,
+                        "size": item["size"],
+                    },
+                )
+
+            cloned += 1
+
+        logger.info(f"Cloned: {cloned}, Skipped: {skipped}")
+        return folder
+
+    def pull(self, path: Path) -> None:
+        """Pull latest files for a checkout folder.
+
+        Re-lists the remote folder and downloads new/updated files.
+        Existing files are refreshed via their sidecar.
+        """
+        metadata_path = path / ".gax.yaml"
+        if not metadata_path.exists():
+            raise ValueError(f"No .gax.yaml found in {path}")
+
+        meta = yaml.safe_load(metadata_path.read_text())
+        folder_id = meta.get("folder_id")
+        if not folder_id:
+            raise ValueError("No folder_id in .gax.yaml")
+
+        recursive = meta.get("recursive", False)
+        remote_items = list_folder(folder_id, recursive=recursive)
+
+        # Build set of remote file IDs (non-folders)
+        remote_by_path = {
+            item["path"]: item for item in remote_items if not item["is_folder"]
+        }
+
+        # Pull existing tracked files
+        updated = 0
+        for sidecar in path.rglob("*.gax.md"):
+            if sidecar.name == ".gax.yaml":
+                continue
+            # Skip gax resource files (they have their own pull)
+            if not sidecar.name.endswith(".gax.md"):
+                continue
+            # Sidecar → actual file
+            name = sidecar.name
+            if not name.endswith(".gax.md"):
+                continue
+            actual = sidecar.parent / name[:-7]  # strip .gax.md
+            if actual.exists():
+                try:
+                    File().pull(actual)
+                    updated += 1
+                except Exception as e:
+                    logger.warning(f"{actual}: {e}")
+
+        # Download new remote files
+        new_files = 0
+        for rel_path, item in remote_by_path.items():
+            local_path = path / rel_path
+            mime = item["mimeType"]
+
+            if local_path.exists():
+                continue
+            if mime in WORKSPACE_MIME_TYPES and _workspace_file_exists(path, item):
+                continue
+
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(f"New file: {rel_path}")
+
+            if mime in WORKSPACE_MIME_TYPES:
+                self._clone_workspace_file(item, path)
+            else:
+                download_file(item["id"], local_path)
+                create_tracking_file(
+                    local_path,
+                    {
+                        "id": item["id"],
+                        "name": item["name"],
+                        "mimeType": mime,
+                        "size": item["size"],
+                    },
+                )
+
+            new_files += 1
+
+        # Ensure subfolders exist
+        for item in remote_items:
+            if item["is_folder"]:
+                (path / item["path"]).mkdir(parents=True, exist_ok=True)
+
+        # Update metadata timestamp
+        meta["checked_out"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with open(metadata_path, "w") as f:
+            yaml.dump(
+                meta,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+
+        logger.info(f"Updated: {updated}, New: {new_files}")
+
+    def _clone_workspace_file(self, item: dict, folder: Path) -> None:
+        """Clone a Google Workspace file using its native gax resource."""
+        mime = item["mimeType"]
+        resource_type = WORKSPACE_MIME_TYPES[mime]
+        file_id = item["id"]
+        parent = item["path"].rsplit("/", 1)[0] if "/" in item["path"] else ""
+        target_dir = folder / parent if parent else folder
+
+        url = f"https://docs.google.com/{_workspace_url_path(resource_type)}/d/{file_id}/edit"
+        safe_name = re.sub(r'[<>:"/\\|?*]', "-", item["name"])
+        safe_name = re.sub(r"\s+", "_", safe_name)
+
+        if resource_type == "doc":
+            from .gdoc.doc import Tab
+
+            output = target_dir / f"{safe_name}.doc.gax.md"
+            if not output.exists():
+                Tab().clone(url, output=output)
+        elif resource_type == "sheet":
+            from .gsheet.sheet import SheetTab
+
+            output = target_dir / f"{safe_name}.sheet.gax.md"
+            if not output.exists():
+                SheetTab().clone(url, output=output)
+        elif resource_type == "form":
+            from .form import Form
+
+            output = target_dir / f"{safe_name}.form.gax.md"
+            if not output.exists():
+                Form().clone(url, output=output)
+
+
+def _workspace_url_path(resource_type: str) -> str:
+    """Map resource type to Google URL path segment."""
+    return {
+        "doc": "document",
+        "sheet": "spreadsheets",
+        "form": "forms",
+    }[resource_type]
+
+
+def _workspace_file_exists(folder: Path, item: dict) -> bool:
+    """Check if a Workspace file was already cloned as a .gax.md file."""
+    mime = item["mimeType"]
+    resource_type = WORKSPACE_MIME_TYPES.get(mime, "")
+    safe_name = re.sub(r'[<>:"/\\|?*]', "-", item["name"])
+    safe_name = re.sub(r"\s+", "_", safe_name)
+    parent = item["path"].rsplit("/", 1)[0] if "/" in item["path"] else ""
+    target_dir = folder / parent if parent else folder
+
+    ext_map = {"doc": ".doc.gax.md", "sheet": ".sheet.gax.md", "form": ".form.gax.md"}
+    ext = ext_map.get(resource_type, "")
+    return (target_dir / f"{safe_name}{ext}").exists() if ext else False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1750,3 +1750,121 @@ class TestDriveFileE2E:
 
         finally:
             _delete_drive_file(file_id)
+
+
+def _create_drive_folder(
+    name: str, file_contents: dict[str, str]
+) -> tuple[str, list[str]]:
+    """Create a Drive folder with text files. Returns (folder_id, [file_ids])."""
+    creds = get_authenticated_credentials()
+    service = build("drive", "v3", credentials=creds)
+
+    # Create folder
+    folder = (
+        service.files()
+        .create(
+            body={"name": name, "mimeType": "application/vnd.google-apps.folder"},
+            fields="id",
+        )
+        .execute()
+    )
+    folder_id = folder["id"]
+    file_ids = [folder_id]
+
+    # Create files in folder
+    import io
+    from googleapiclient.http import MediaIoBaseUpload
+
+    for fname, content in file_contents.items():
+        media = MediaIoBaseUpload(
+            io.BytesIO(content.encode("utf-8")), mimetype="text/plain"
+        )
+        f = (
+            service.files()
+            .create(
+                body={"name": fname, "parents": [folder_id]},
+                media_body=media,
+                fields="id",
+            )
+            .execute()
+        )
+        file_ids.append(f["id"])
+
+    return folder_id, file_ids
+
+
+def _delete_drive_files(file_ids: list[str]) -> None:
+    """Delete multiple Drive files/folders."""
+    for fid in file_ids:
+        _delete_drive_file(fid)
+
+
+@pytest.mark.e2e
+class TestDriveFolderE2E:
+    """End-to-end tests for Google Drive folder checkout."""
+
+    def test_checkout_pull_cycle(self, check_auth, temp_dir):
+        """Test: create folder with files -> checkout -> verify -> pull."""
+        folder_id, file_ids = _create_drive_folder(
+            f"{E2E_PREFIX}_folder",
+            {
+                "readme.txt": f"{E2E_PREFIX} readme content\n",
+                "notes.txt": f"{E2E_PREFIX} notes content\n",
+            },
+        )
+        try:
+            # Checkout
+            output = temp_dir / "test.drive.gax.md.d"
+            result = _run_gax("file", "checkout", folder_id, "-o", str(output))
+            assert result.returncode == 0, f"Checkout failed: {result.stderr}"
+            assert output.exists()
+            assert (output / ".gax.yaml").exists()
+
+            # Verify files
+            assert (output / "readme.txt").exists()
+            assert f"{E2E_PREFIX} readme content" in (output / "readme.txt").read_text()
+            assert (output / "notes.txt").exists()
+
+            # Verify sidecars
+            assert Path(str(output / "readme.txt") + ".gax.md").exists()
+            assert Path(str(output / "notes.txt") + ".gax.md").exists()
+
+            # Verify .gax.yaml
+            import yaml
+
+            meta = yaml.safe_load((output / ".gax.yaml").read_text())
+            assert meta["type"] == "gax/drive-checkout"
+            assert meta["folder_id"] == folder_id
+
+            # Pull
+            result = _run_gax("pull", str(output))
+            assert result.returncode == 0, f"Pull failed: {result.stderr}"
+
+            # Content should still be valid after pull
+            assert f"{E2E_PREFIX} readme content" in (output / "readme.txt").read_text()
+
+        finally:
+            _delete_drive_files(file_ids)
+
+    def test_checkout_incremental(self, check_auth, temp_dir):
+        """Test: checkout skips existing files on re-run."""
+        folder_id, file_ids = _create_drive_folder(
+            f"{E2E_PREFIX}_incr",
+            {"file1.txt": "content1\n"},
+        )
+        try:
+            output = temp_dir / "incr.drive.gax.md.d"
+
+            # First checkout
+            result = _run_gax("file", "checkout", folder_id, "-o", str(output))
+            assert result.returncode == 0
+
+            # Second checkout — should skip existing
+            result = _run_gax("file", "checkout", folder_id, "-o", str(output))
+            assert result.returncode == 0
+
+            # File should still be there
+            assert (output / "file1.txt").exists()
+
+        finally:
+            _delete_drive_files(file_ids)


### PR DESCRIPTION
## Summary

- Add `gax file checkout <folder-url> [-R]` to clone a Drive folder to a local directory
- `Folder` class in `gdrive.py` with `checkout()` and `pull()` operations
- Flat by default, `-R` flag enables recursive subfolder traversal
- Google Workspace files (Docs, Sheets, Forms) are cloned via their native gax resource instead of binary download
- Per-file `.gax.md` sidecars for individual file operations within the folder
- Unified `gax pull` support via `gax/drive-checkout` type dispatch

## Test plan

- [x] Unit tests pass (296 passed)
- [x] E2e: checkout folder with text files, verify content + sidecars + .gax.yaml
- [x] E2e: incremental checkout skips existing files
- [x] E2e: unified pull refreshes checked-out folder
- [ ] Manual: test with folder containing Google Docs/Sheets (Workspace file dispatch)
- [ ] Manual: test `-R` flag with nested subfolders

🤖 Generated with [Claude Code](https://claude.com/claude-code)