### PR TITLE
feat: Google Tasks sync (ADR 031)

### DIFF
--- a/ADR/031-task-sync.md
+++ b/ADR/031-task-sync.md
@@ -1,0 +1,327 @@
+# ADR 031: Google Tasks Sync
+
+## Status
+
+Proposed
+
+## Context
+
+gax covers Docs, Sheets, Forms, Gmail, Calendar, Contacts, and Drive. Google Tasks is the remaining core productivity API. Tasks are lightweight to-do items organized in task lists, with optional due dates, notes, and subtask nesting.
+
+Use cases:
+
+- LLM agents managing to-do lists through local files
+- Syncing task lists for offline review and batch editing
+- Round-tripping task changes (title, notes, status, due date) back to Google
+
+The Google Tasks API is simple compared to Calendar or Docs. A task has ~10 fields. Task lists are flat containers (like calendars). Tasks within a list can be nested one level (parent/subtask).
+
+## Decision
+
+### Conceptual Mapping
+
+| Concept | Calendar | Tasks |
+|---------|----------|-------|
+| Container | Calendar | Task List |
+| Item | Event | Task |
+| List containers | `cal calendars` | `task lists` |
+| List items | `cal list` | `task list` |
+| Item resource | `Event(Resource)` | `Task(Resource)` |
+| Nesting | N/A | Subtasks (one level) |
+
+### Data Model
+
+```python
+@dataclass
+class TaskItem:
+    id: str
+    tasklist: str              # task list ID
+    source: str                # URL to tasks.google.com
+    synced: str                # ISO timestamp
+    title: str
+    status: str = "needsAction"  # needsAction | completed
+    due: str = ""              # ISO date (date only, no time)
+    notes: str = ""            # plain text description
+    completed: str = ""        # ISO timestamp when completed
+    parent: str = ""           # parent task ID (for subtasks)
+    position: str = ""         # ordering position within list
+    updated: str = ""          # ISO timestamp, last modified
+```
+
+### File Format
+
+Single task (`.task.gax.yaml`):
+
+```yaml
+---
+type: gax/task
+id: MTIzNDU2Nzg5
+tasklist: MDExMjIzMzQ0NQ
+source: https://tasks.google.com/task/...
+synced: 2026-04-19T10:00:00Z
+---
+title: Buy groceries
+status: needsAction
+due: 2026-04-21
+notes: |
+  Milk, eggs, bread.
+  Check if we need coffee filters.
+```
+
+The YAML header contains only gax plumbing (type, id, source, synced). The YAML body contains the actual task data (title, status, due, notes). This separates sync metadata from user-editable content.
+
+The `.gax.yaml` extension signals that both header and body are YAML, distinguishing it from `.gax.md` files where the body is markdown.
+
+Task list file supports two formats via `--format md|yaml`:
+
+**Markdown format** (default, `.tasks.gax.md`):
+
+```markdown
+---
+type: gax/task-list
+id: MDExMjIzMzQ0NQ
+source: https://tasks.google.com/...
+synced: 2026-04-19T10:00:00Z
+title: Work
+---
+- [ ] Buy groceries `MTIzNDU2ODA5` due:2026-04-21
+  - [ ] Milk `MTIzNDU2ODE5`
+  - [ ] Bread `MTIzNDU2ODI5`
+- [x] Write ADR `MTIzNDU2Nzk5` due:2026-04-20
+- [ ] Review PR #38 `MTIzNDU2Nzg5`
+```
+
+Scannable, GitHub-rendered checkboxes. Pushable for quick operations: check off, rename, add, reorder, set due date. Does not include notes or timestamps -- those live in individual task files.
+
+Parsing rules:
+- `- [ ]` / `- [x]` = status (needsAction / completed)
+- Backtick-wrapped = task ID
+- `due:YYYY-MM-DD` = due date
+- Indented items = subtasks
+- No ID = new task (create on push)
+
+**YAML format** (`--format yaml`, `.tasks.gax.yaml`):
+
+```yaml
+---
+type: gax/task-list
+id: MDExMjIzMzQ0NQ
+source: https://tasks.google.com/...
+synced: 2026-04-19T10:00:00Z
+title: Work
+---
+- title: Buy groceries
+  id: MTIzNDU2ODA5
+  status: needsAction
+  due: 2026-04-21
+  updated: 2026-04-18T14:30:00Z
+  notes: |
+    Milk, eggs, bread.
+    Check if we need coffee filters.
+  subtasks:
+    - title: Milk
+      id: MTIzNDU2ODE5
+      status: needsAction
+    - title: Bread
+      id: MTIzNDU2ODI5
+      status: needsAction
+
+- title: Write ADR
+  id: MTIzNDU2Nzk5
+  status: completed
+  due: 2026-04-20
+  completed: 2026-04-19T15:30:00Z
+```
+
+Full-fidelity format with notes, timestamps, and all fields. Pushable for detailed edits. Extension is `.tasks.gax.yaml` to reflect the YAML body.
+
+### CLI Structure
+
+Follows the Calendar pattern (`cal` group with `event` subgroup):
+
+```
+gax task
++-- lists                                # List available task lists
++-- list [--tasklist NAME] [--all]       # View tasks (default: incomplete only)
++-- clone <tasklist-url> [--format]      # Clone task list as single file
++-- checkout <tasklist-url>              # Checkout as folder of individual tasks
++-- pull <file-or-folder>                # Refresh
+|
++-- new [--tasklist NAME] "Title"        # Create new task
++-- pull <file>                          # Refresh single task
++-- diff <file>                          # Diff single task
++-- push <file>                          # Push changes
++-- done <file>                          # Mark task completed
++-- delete <file>                        # Delete task
+```
+
+**`gax task lists`** -- List available task lists (like `cal calendars`).
+
+**`gax task list`** -- Show tasks from a task list. Default: show only incomplete tasks. `--all` includes completed.
+
+**`gax task clone <url> [--format md|yaml]`** -- Clone task list as single file. Default `md` creates `.tasks.gax.md` with checkbox body. `yaml` creates `.tasks.gax.yaml` with full-fidelity YAML body.
+
+**`gax task checkout <url>`** -- Create `.tasks.gax.md.d/` folder with individual `.task.gax.yaml` files.
+
+**`gax task new "Title"`** -- Create a new task on Google and write local `.task.gax.yaml` file. Uses `--tasklist` to select list (default: first/primary list).
+
+**`gax task done <file>`** -- Shortcut for setting `status: completed` and pushing. Convenience command since this is the most common mutation.
+
+### Checkout Layout
+
+```
+Work.tasks.gax.md.d/
++-- .gax.yaml
++-- Buy_groceries.task.gax.yaml
++-- Write_ADR.task.gax.yaml
++-- Milk.task.gax.yaml
++-- Bread.task.gax.yaml
+```
+
+Subtasks are kept flat in the folder (not nested directories). The `parent` field in each file preserves the hierarchy. This avoids the complexity of nested tab directories for a single level of nesting.
+
+`.gax.yaml`:
+
+```yaml
+type: gax/task-checkout
+tasklist_id: MDExMjIzMzQ0NQ
+url: https://tasks.google.com/...
+title: Work
+checked_out: 2026-04-19T10:00:00Z
+```
+
+### Resource Classes
+
+Two classes following the Calendar pattern:
+
+**`TaskList`** -- Collection resource. Methods: `clone`, `pull`, `checkout`, `pull` (folder), `tab_list` (renamed: `lists`).
+
+**`Task(Resource)`** -- Single task. Methods: `clone`, `new`, `pull`, `diff`, `push`, `delete`.
+
+### Diff Format
+
+Field-by-field diff like Calendar events:
+
+```
+~ title: "Review PR #38" -> "Review PR #38 — nested tabs"
+~ status: "needsAction" -> "completed"
++ completed: "2026-04-19T15:30:00Z"
+```
+
+### Pushable Fields
+
+| Field | Editable | Notes |
+|-------|----------|-------|
+| `id` | No | Server-assigned |
+| `tasklist` | No | Cannot move tasks between lists via API |
+| `source` | No | Generated URL |
+| `synced` | No | Updated on pull |
+| `title` | Yes | |
+| `status` | Yes | needsAction or completed |
+| `due` | Yes | Date only (no time component) |
+| `notes` | Yes | In YAML body |
+| `completed` | No | Set automatically when status changes |
+| `parent` | Yes | Can reparent a subtask |
+| `position` | Yes | Reorder within list |
+
+### OAuth Scope
+
+```python
+"https://www.googleapis.com/auth/tasks"  # Read-write
+```
+
+Added to `auth.py` alongside existing scopes. Users need to re-authenticate once.
+
+### API Helpers
+
+```python
+def get_tasks_service():
+    """Build Tasks API v1 service."""
+
+def list_tasklists(*, service=None) -> list[dict]:
+    """List all task lists."""
+
+def list_tasks(tasklist_id: str, *, show_completed=False, service=None) -> list[dict]:
+    """List tasks in a task list. Handles pagination."""
+
+def get_task(tasklist_id: str, task_id: str, *, service=None) -> dict:
+    """Get a single task."""
+
+def create_task(tasklist_id: str, body: dict, *, service=None) -> dict:
+    """Create a task. Returns created task dict."""
+
+def update_task(tasklist_id: str, task_id: str, body: dict, *, service=None) -> dict:
+    """Update a task."""
+
+def delete_task(tasklist_id: str, task_id: str, *, service=None) -> None:
+    """Delete a task."""
+
+def complete_task(tasklist_id: str, task_id: str, *, service=None) -> dict:
+    """Mark task completed (convenience)."""
+```
+
+### URL Patterns
+
+Google Tasks URLs are not as standardized as other Google products. Support:
+
+- `https://tasks.google.com/task/<id>`
+- Task list IDs passed directly via `--tasklist`
+- Fallback: use default/primary task list
+
+## Edge Cases
+
+**Subtask ordering**: The Tasks API returns subtasks in `position` order under their parent. On pull, subtasks are placed after their parent in the TSV listing. On push, `position` and `parent` fields are respected.
+
+**Completed tasks**: By default, `task list` and `clone` exclude completed tasks (API default). `--all` includes them. Completed tasks have `status: completed` and a `completed` timestamp.
+
+**Empty notes**: If the task has no notes, the `notes` key is omitted from the YAML body.
+
+**Task list deletion**: Not supported via CLI. Task lists are containers managed through the Google UI.
+
+## Consequences
+
+### Positive
+
+- Completes gax coverage of core Google productivity APIs
+- Simple resource with few fields -- low implementation complexity
+- Follows established Calendar patterns -- no new concepts
+- `done` command provides fast workflow for the most common operation
+- TSV list format enables quick scanning and AI parsing
+
+### Negative
+
+- New OAuth scope requires re-authentication
+- Google Tasks URLs are not well-standardized -- ID-based addressing may be needed more than URL-based
+- Tasks API v1 has limited features (no labels, no priorities, no recurring tasks)
+
+### Neutral
+
+- Subtasks are flat in checkout folders (parent field preserves hierarchy without directory nesting)
+- Task positions are opaque strings -- reordering requires reading current positions first
+
+## Alternatives Considered
+
+### 1. Nested directories for subtasks
+
+Put subtasks in a subdirectory under the parent task.
+
+**Rejected**: Subtasks are only one level deep and have minimal content. Directory nesting adds complexity for little benefit. The `parent` field is sufficient.
+
+### 2. Single format for task lists
+
+Use only YAML or only markdown for the list file.
+
+**Rejected**: Markdown checkboxes are ideal for quick scanning and simple edits (check off, rename). YAML is needed for full-fidelity round-trips (notes, timestamps). Both formats are supported via `--format md|yaml`.
+
+### 3. Skip task lists, work only with individual tasks
+
+Only support single-task operations, no list/checkout.
+
+**Rejected**: Most users think in terms of task lists, not individual tasks. The list view is essential for scanning and batch operations.
+
+## References
+
+- ADR 007: Calendar Sync (command structure reference)
+- ADR 022: Simplified CLI Model
+- ADR 026: Clone file / Checkout directory
+- Google Tasks API: https://developers.google.com/tasks/reference/rest

--- a/gax/auth.py
+++ b/gax/auth.py
@@ -20,6 +20,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/gmail.settings.basic",  # filters
     "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/tasks",  # read/write tasks
     "https://www.googleapis.com/auth/forms.body",  # read/write form structure
     "https://www.googleapis.com/auth/contacts",  # read/write contacts
 ]

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -36,6 +36,7 @@ from .mail import Thread, Mailbox
 from .label import Label
 from .filter import Filter
 from .gcal import Cal, Event
+from .gtask import TaskList, Task as TaskResource
 from .form import Form
 from .draft import Draft
 from .contacts import Contacts
@@ -2084,6 +2085,240 @@ def cal_event_delete_cmd(file_path: Path, yes: bool):
 
 
 # =============================================================================
+# Task commands
+# =============================================================================
+
+
+@docs.section("resource")
+@click.group(name="task")
+def task_group():
+    """Google Tasks sync commands."""
+    pass
+
+
+@task_group.command(name="lists")
+def task_lists_cmd():
+    """List available task lists."""
+    try:
+        TaskList().lists(sys.stdout)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@task_group.command(name="list")
+@click.argument("tasklist", required=False)
+@click.option("--all", "show_all", is_flag=True, help="Include completed tasks")
+@click.option(
+    "-f",
+    "--format",
+    "fmt",
+    type=click.Choice(["md", "yaml"]),
+    default="md",
+    help="Output format (default: md)",
+)
+def task_list_cmd(tasklist: str | None, show_all: bool, fmt: str):
+    """View tasks from a task list."""
+    try:
+        TaskList().list(sys.stdout, tasklist=tasklist, show_all=show_all, fmt=fmt)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@task_group.command(name="clone")
+@click.argument("tasklist", required=False)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help="Output file path",
+)
+@click.option("--all", "show_all", is_flag=True, help="Include completed tasks")
+@click.option(
+    "-f",
+    "--format",
+    "fmt",
+    type=click.Choice(["md", "yaml"]),
+    default="md",
+    help="Output format (default: md)",
+)
+def task_clone_cmd(
+    tasklist: str | None, output: Path | None, show_all: bool, fmt: str
+):
+    """Clone a task list to a single file."""
+    try:
+        path = TaskList().clone(
+            tasklist=tasklist, output=output, fmt=fmt, show_all=show_all
+        )
+        from .ui import success
+
+        success(f"Created: {path}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="checkout")
+@click.argument("tasklist", required=False)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help="Output folder path",
+)
+@click.option("--all", "show_all", is_flag=True, help="Include completed tasks")
+def task_checkout_cmd(tasklist: str | None, output: Path | None, show_all: bool):
+    """Checkout a task list as a folder of individual task files."""
+    try:
+        cloned, skipped = TaskList().checkout(
+            tasklist=tasklist, output=output, show_all=show_all
+        )
+        from .ui import success
+
+        success(f"Checked out: {cloned}, Skipped: {skipped}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="pull")
+@click.argument("file_path", type=click.Path(exists=True, path_type=Path))
+def task_pull_cmd(file_path: Path):
+    """Pull latest task data from API."""
+    try:
+        name = file_path.name
+        if name.endswith(".tasks.gax.md") or name.endswith(".tasks.gax.yaml"):
+            TaskList().pull(file_path)
+        else:
+            TaskResource().pull(file_path)
+        from .ui import success
+
+        success(f"Updated: {file_path}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="new")
+@click.argument("title")
+@click.option(
+    "--tasklist",
+    help="Task list name, ID, or index (default: first list)",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help="Output file path",
+)
+def task_new_cmd(title: str, tasklist: str | None, output: Path | None):
+    """Create a new task on Google."""
+    try:
+        path = TaskResource().new(title, tasklist=tasklist, output=output)
+        from .ui import success
+
+        success(f"Created: {path}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="diff")
+@click.argument("file_path", type=click.Path(exists=True, path_type=Path))
+def task_diff_cmd(file_path: Path):
+    """Show differences between local task and remote."""
+    try:
+        diff_text = TaskResource().diff(file_path)
+        if diff_text is None:
+            click.echo("No changes.")
+        else:
+            click.echo(diff_text)
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="push")
+@click.argument("file_path", type=click.Path(exists=True, path_type=Path))
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
+def task_push_cmd(file_path: Path, yes: bool):
+    """Push local task changes to API."""
+    try:
+        t = TaskResource()
+        diff_text = t.diff(file_path)
+        if diff_text is None:
+            click.echo("No changes to push.")
+            return
+        if not yes:
+            click.echo(diff_text)
+            if not click.confirm("Push these changes?"):
+                click.echo("Cancelled.")
+                return
+        title = t.push(file_path)
+        from .ui import success
+
+        success(f"Pushed: {title}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="done")
+@click.argument("file_path", type=click.Path(exists=True, path_type=Path))
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
+def task_done_cmd(file_path: Path, yes: bool):
+    """Mark a task as completed and push."""
+    try:
+        if not yes:
+            if not click.confirm(f"Mark {file_path.name} as done?"):
+                click.echo("Cancelled.")
+                return
+        title = TaskResource().done(file_path)
+        from .ui import success
+
+        success(f"Done: {title}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+@task_group.command(name="delete")
+@click.argument("file_path", type=click.Path(exists=True, path_type=Path))
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
+def task_delete_cmd(file_path: Path, yes: bool):
+    """Delete a task from Google and local file."""
+    try:
+        if not yes:
+            if not click.confirm(f"Delete {file_path.name}?"):
+                click.echo("Cancelled.")
+                return
+        title = TaskResource().delete(file_path)
+        from .ui import success
+
+        success(f"Deleted: {title}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
+# =============================================================================
 # Form commands
 # =============================================================================
 
@@ -2467,7 +2702,7 @@ def doc_clone(url: str, output: Path | None, with_comments: bool, quiet: bool):
             document_id = extract_doc_id(url)
             tabs = get_tabs_list(document_id)
             if len(tabs["tabs"]) > 1:
-                first_tab = tabs["tabs"][0]["title"]
+                first_tab = tabs["tabs"][0].title
                 click.echo(
                     f'  Tab "{first_tab}" cloned (1 of {len(tabs["tabs"])} tabs).\n'
                     f"  For all tabs: gax doc checkout {url}"
@@ -2552,6 +2787,7 @@ main.add_command(mailbox_group, name="mailbox")
 main.add_command(mail_label)  # Flattened from mail.label (ADR 020)
 main.add_command(mail_filter)  # Flattened from mail.filter (ADR 020)
 main.add_command(cal_group)
+main.add_command(task_group)
 main.add_command(form)
 main.add_command(draft)  # Flattened from mail.draft (ADR 020)
 main.add_command(contacts)

--- a/gax/cli_helper.py
+++ b/gax/cli_helper.py
@@ -15,6 +15,7 @@ from .gsheet.frontmatter import parse_content
 from .label import Label
 from .filter import Filter
 from .gcal import Cal, Event
+from .gtask import TaskList as TaskListResource, Task as TaskSingleResource
 from .form import Form
 from .draft import Draft
 from .contacts import Contacts
@@ -94,6 +95,10 @@ def _detect_file_type(file_path: Path) -> str | None:
         return "gax/draft"
     if name.endswith(".cal.gax.md"):
         return "gax/cal"
+    if name.endswith(".task.gax.yaml"):
+        return "gax/task"
+    if name.endswith(".tasks.gax.md") or name.endswith(".tasks.gax.yaml"):
+        return "gax/task-list"
     if name.endswith(".form.gax.md"):
         return "gax/form"
     if ".contacts." in name or name.endswith(".contacts.gax.md"):
@@ -176,6 +181,17 @@ def _pull_folder(
             from .gdrive import Folder
 
             Folder().pull(folder_path)
+            return True, "updated"
+
+        elif checkout_type == "gax/task-checkout":
+            # Task checkouts pull in-place
+            if scratch_path.exists():
+                shutil.rmtree(scratch_path)
+            for task_file in sorted(folder_path.glob("*.task.gax.yaml")):
+                try:
+                    TaskSingleResource().pull(task_file)
+                except ValueError:
+                    pass
             return True, "updated"
 
         else:
@@ -401,6 +417,21 @@ def _push_file(
             except ValueError as e:
                 return False, str(e)
 
+        elif file_type == "gax/task":
+            try:
+                t = TaskSingleResource()
+                diff_text = t.diff(file_path)
+                if diff_text is None:
+                    return True, "no changes"
+                if not yes:
+                    click.echo(diff_text)
+                    if not click.confirm("Push these changes?"):
+                        return False, "cancelled"
+                t.push(file_path)
+                return True, "pushed"
+            except ValueError as e:
+                return False, str(e)
+
         elif file_type == "gax/file":
             # This is a tracking file, find the actual file
             from .gdrive import read_tracking_file
@@ -578,6 +609,20 @@ def _pull_file(file_path: Path, verbose: bool = False) -> tuple[bool, str]:
         elif file_type == "gax/cal-list":
             try:
                 Cal().pull(file_path)
+                return True, "updated"
+            except ValueError as e:
+                return False, str(e)
+
+        elif file_type == "gax/task":
+            try:
+                TaskSingleResource().pull(file_path)
+                return True, "updated"
+            except ValueError as e:
+                return False, str(e)
+
+        elif file_type == "gax/task-list":
+            try:
+                TaskListResource().pull(file_path)
                 return True, "updated"
             except ValueError as e:
                 return False, str(e)

--- a/gax/gdoc/doc.py
+++ b/gax/gdoc/doc.py
@@ -194,8 +194,10 @@ def _tab_content_to_markdown(doc: dict, tab: dict) -> str:
     """Convert a tab's body content to markdown via the IR."""
     from . import ir
 
-    body = tab.get("documentTab", {}).get("body", {}).get("content", [])
-    blocks = ir.from_doc_json(body, lists=doc.get("lists"))
+    doc_tab = tab.get("documentTab", {})
+    body = doc_tab.get("body", {}).get("content", [])
+    lists = doc_tab.get("lists") or doc.get("lists")
+    blocks = ir.from_doc_json(body, lists=lists)
     md = ir.render_markdown(blocks)
     # Post-process: extract base64 images to blob store
     md = extract_images_to_store(md)

--- a/gax/gtask.py
+++ b/gax/gtask.py
@@ -1,0 +1,830 @@
+"""Google Tasks sync for gax.
+
+Resource module -- follows the gcal.py reference pattern.
+
+Task list viewing and task editing (ADR 031).
+
+Module structure
+================
+
+  Data class           -- TaskItem
+  API helpers          -- service, list/get/create/update/delete tasks
+  Inverse pairs        -- api_to_task / task_to_api_body
+  Task file format     -- task_to_yaml / yaml_to_task (split header/body YAML)
+  List format          -- markdown checkboxes and YAML list formats
+  Resolution helpers   -- resolve_tasklist_id
+  TaskList             -- collection resource (lists, clone, pull, checkout)
+  Task(Resource)       -- single task resource (clone, new, pull, diff, push, done, delete)
+
+Design decisions
+================
+
+Same conventions as gcal.py (see its docstring for full rationale).
+Additional notes specific to tasks:
+
+  Split YAML format: header has gax metadata (type, id, tasklist, source, synced),
+  body has user-editable task data (title, status, due, notes). Extension: .task.gax.yaml.
+
+  Two list formats via --format:
+    md (default)  -- markdown checkboxes, .tasks.gax.md
+    yaml          -- full-fidelity YAML list, .tasks.gax.yaml
+
+  Task push handles both create (no ID) and update (has ID).
+  After creating, the local file is updated with the new task ID.
+
+  done() is a convenience shortcut: set status=completed + push.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from googleapiclient.discovery import build
+
+from .auth import get_authenticated_credentials
+from .resource import Resource
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Data class
+# =============================================================================
+
+
+@dataclass
+class TaskItem:
+    """A Google Tasks task."""
+
+    id: str
+    tasklist: str  # task list ID
+    source: str  # URL
+    synced: str  # ISO timestamp
+    title: str
+    status: str = "needsAction"  # needsAction | completed
+    due: str = ""  # ISO date (YYYY-MM-DD, no time)
+    notes: str = ""
+    completed: str = ""  # ISO timestamp when completed
+    parent: str = ""  # parent task ID (subtasks)
+    position: str = ""  # ordering within list
+    updated: str = ""  # ISO timestamp, last modified
+
+
+# =============================================================================
+# API helpers
+# =============================================================================
+
+
+def get_tasks_service(*, service=None):
+    """Get authenticated Tasks API v1 service."""
+    if service is not None:
+        return service
+    creds = get_authenticated_credentials()
+    return build("tasks", "v1", credentials=creds)
+
+
+def list_tasklists(*, service=None) -> list[dict]:
+    """List all task lists. Returns list of {id, title} dicts."""
+    service = get_tasks_service(service=service)
+
+    result = service.tasklists().list().execute()
+    tasklists = []
+    for tl in result.get("items", []):
+        tasklists.append(
+            {
+                "id": tl["id"],
+                "title": tl.get("title", tl["id"]),
+            }
+        )
+    return tasklists
+
+
+def list_tasks(
+    tasklist_id: str, *, show_completed: bool = False, service=None
+) -> list[dict]:
+    """List tasks in a task list. Handles pagination."""
+    service = get_tasks_service(service=service)
+
+    tasks = []
+    page_token = None
+
+    while True:
+        kwargs: dict[str, Any] = {
+            "tasklist": tasklist_id,
+            "maxResults": 100,
+        }
+        if show_completed:
+            kwargs["showCompleted"] = True
+            kwargs["showHidden"] = True
+        if page_token:
+            kwargs["pageToken"] = page_token
+
+        result = service.tasks().list(**kwargs).execute()
+
+        for task in result.get("items", []):
+            tasks.append(task)
+
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
+
+    return tasks
+
+
+def get_task(tasklist_id: str, task_id: str, *, service=None) -> dict:
+    """Get a single task."""
+    service = get_tasks_service(service=service)
+    return service.tasks().get(tasklist=tasklist_id, task=task_id).execute()
+
+
+def create_task(
+    tasklist_id: str, body: dict, *, parent: str = "", service=None
+) -> dict:
+    """Create a task. Returns created task dict."""
+    service = get_tasks_service(service=service)
+    kwargs: dict[str, Any] = {"tasklist": tasklist_id, "body": body}
+    if parent:
+        kwargs["parent"] = parent
+    return service.tasks().insert(**kwargs).execute()
+
+
+def update_task(
+    tasklist_id: str, task_id: str, body: dict, *, service=None
+) -> dict:
+    """Update a task. Returns updated task dict."""
+    service = get_tasks_service(service=service)
+    return (
+        service.tasks()
+        .update(tasklist=tasklist_id, task=task_id, body=body)
+        .execute()
+    )
+
+
+def delete_task(tasklist_id: str, task_id: str, *, service=None) -> None:
+    """Delete a task."""
+    service = get_tasks_service(service=service)
+    service.tasks().delete(tasklist=tasklist_id, task=task_id).execute()
+
+
+# =============================================================================
+# Inverse pair: TaskItem <-> API
+# =============================================================================
+
+
+def api_to_task(task: dict, tasklist_id: str) -> TaskItem:
+    """Convert API task dict to TaskItem dataclass."""
+    task_id = task.get("id", "")
+
+    # Due date: API returns RFC 3339 with time, store as date-only
+    due_raw = task.get("due", "")
+    due = due_raw[:10] if due_raw else ""
+
+    # Completed timestamp
+    completed = task.get("completed", "")
+
+    return TaskItem(
+        id=task_id,
+        tasklist=tasklist_id,
+        source=task.get("selfLink", ""),
+        synced=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        title=task.get("title", ""),
+        status=task.get("status", "needsAction"),
+        due=due,
+        notes=task.get("notes", ""),
+        completed=completed,
+        parent=task.get("parent", ""),
+        position=task.get("position", ""),
+        updated=task.get("updated", ""),
+    )
+
+
+def task_to_api_body(task: TaskItem) -> dict:
+    """Convert TaskItem to API request body (for create/update)."""
+    body: dict[str, Any] = {
+        "title": task.title,
+        "status": task.status,
+    }
+
+    if task.due:
+        body["due"] = f"{task.due}T00:00:00.000Z"
+
+    if task.notes:
+        body["notes"] = task.notes
+
+    return body
+
+
+# =============================================================================
+# Task file format -- split header/body YAML (.task.gax.yaml)
+# =============================================================================
+
+
+def task_to_yaml(task: TaskItem) -> str:
+    """Serialize TaskItem to split YAML (header + body)."""
+    header: dict[str, Any] = {
+        "type": "gax/task",
+        "id": task.id,
+        "tasklist": task.tasklist,
+        "source": task.source,
+        "synced": task.synced,
+    }
+
+    body: dict[str, Any] = {
+        "title": task.title,
+        "status": task.status,
+    }
+    if task.due:
+        body["due"] = task.due
+    if task.notes:
+        body["notes"] = task.notes
+    if task.completed:
+        body["completed"] = task.completed
+    if task.parent:
+        body["parent"] = task.parent
+    if task.updated:
+        body["updated"] = task.updated
+
+    header_str = yaml.dump(
+        header, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+    body_str = yaml.dump(
+        body, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+
+    return f"---\n{header_str}---\n{body_str}"
+
+
+def yaml_to_task(content: str) -> TaskItem:
+    """Parse split YAML content to TaskItem."""
+    if not content.startswith("---"):
+        raise ValueError("Expected YAML frontmatter (---)")
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError("Invalid split YAML format")
+
+    header = yaml.safe_load(parts[1])
+    body = yaml.safe_load(parts[2])
+
+    if header is None:
+        raise ValueError("Empty YAML header")
+    if body is None:
+        body = {}
+
+    if header.get("type") != "gax/task":
+        raise ValueError(f"Expected type gax/task, got {header.get('type')}")
+
+    return TaskItem(
+        id=header.get("id", ""),
+        tasklist=header.get("tasklist", ""),
+        source=header.get("source", ""),
+        synced=header.get("synced", ""),
+        title=body.get("title", ""),
+        status=body.get("status", "needsAction"),
+        due=str(body["due"]) if body.get("due") else "",
+        notes=body.get("notes", ""),
+        completed=body.get("completed", ""),
+        parent=body.get("parent", ""),
+        position=body.get("position", ""),
+        updated=body.get("updated", ""),
+    )
+
+
+# =============================================================================
+# List format -- markdown checkboxes
+# =============================================================================
+
+
+def format_tasks_md(tasks: list[TaskItem]) -> str:
+    """Format tasks as markdown checkboxes.
+
+    Root tasks first, subtasks indented below their parent.
+    Format: - [ ] Title `ID` due:YYYY-MM-DD
+    """
+    # Group subtasks under parents
+    root_tasks = [t for t in tasks if not t.parent]
+    children: dict[str, list[TaskItem]] = {}
+    for t in tasks:
+        if t.parent:
+            children.setdefault(t.parent, []).append(t)
+
+    lines = []
+    for task in root_tasks:
+        lines.append(_format_task_md_line(task, indent=0))
+        for child in children.get(task.id, []):
+            lines.append(_format_task_md_line(child, indent=1))
+
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+def _format_task_md_line(task: TaskItem, indent: int = 0) -> str:
+    """Format a single task as a markdown checkbox line."""
+    prefix = "  " * indent
+    check = "x" if task.status == "completed" else " "
+    parts = [f"{prefix}- [{check}] {task.title}"]
+    if task.id:
+        parts.append(f"`{task.id}`")
+    if task.due:
+        parts.append(f"due:{task.due}")
+    return " ".join(parts)
+
+
+def parse_tasks_md(content: str) -> list[dict]:
+    """Parse markdown checkbox content to list of task dicts.
+
+    Returns list of dicts with: title, id, status, due, is_subtask.
+    """
+    pattern = re.compile(r"^(\s*)- \[([ xX])\] (.+)$")
+    tasks = []
+
+    for line in content.strip().split("\n"):
+        m = pattern.match(line)
+        if not m:
+            continue
+
+        indent = len(m.group(1))
+        checked = m.group(2).lower() == "x"
+        rest = m.group(3).strip()
+
+        # Extract ID from backticks (from right)
+        task_id = ""
+        id_match = re.search(r"`([^`]+)`", rest)
+        if id_match:
+            task_id = id_match.group(1)
+            rest = rest[: id_match.start()].strip()
+            # Check for due: after the backtick
+            after = m.group(3)[id_match.end() :].strip()
+            due_match = re.search(r"due:(\S+)", after)
+        else:
+            due_match = re.search(r"due:(\S+)", rest)
+
+        # Extract due date
+        due = ""
+        if due_match:
+            due = due_match.group(1)
+            if not task_id:
+                rest = rest[: due_match.start()].strip()
+
+        # Remaining text is the title
+        # Remove trailing due: if it was in the rest
+        title = re.sub(r"\s*due:\S+", "", rest).strip()
+
+        tasks.append(
+            {
+                "title": title,
+                "id": task_id,
+                "status": "completed" if checked else "needsAction",
+                "due": due,
+                "is_subtask": indent >= 2,
+            }
+        )
+
+    return tasks
+
+
+# =============================================================================
+# List format -- YAML
+# =============================================================================
+
+
+def format_tasks_yaml(tasks: list[TaskItem]) -> str:
+    """Format tasks as YAML list body with nested subtasks."""
+    root_tasks = [t for t in tasks if not t.parent]
+    children: dict[str, list[TaskItem]] = {}
+    for t in tasks:
+        if t.parent:
+            children.setdefault(t.parent, []).append(t)
+
+    items = []
+    for task in root_tasks:
+        item = _task_to_yaml_dict(task)
+        subs = children.get(task.id, [])
+        if subs:
+            item["subtasks"] = [_task_to_yaml_dict(s) for s in subs]
+        items.append(item)
+
+    return yaml.dump(
+        items, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+
+
+def _task_to_yaml_dict(task: TaskItem) -> dict:
+    """Convert TaskItem to dict for YAML list format."""
+    d: dict[str, Any] = {
+        "title": task.title,
+        "id": task.id,
+        "status": task.status,
+    }
+    if task.due:
+        d["due"] = task.due
+    if task.notes:
+        d["notes"] = task.notes
+    if task.completed:
+        d["completed"] = task.completed
+    if task.updated:
+        d["updated"] = task.updated
+    return d
+
+
+# =============================================================================
+# Resolution helpers
+# =============================================================================
+
+
+def resolve_tasklist_id(tasklist: str | None) -> tuple[str, str]:
+    """Resolve tasklist name or index to (id, title).
+
+    Supports: name, full ID, numeric index (1-based).
+    Returns first list if tasklist is None.
+    """
+    all_lists = list_tasklists()
+    if not all_lists:
+        raise ValueError("No task lists found")
+
+    if tasklist is None:
+        tl = all_lists[0]
+        return tl["id"], tl["title"]
+
+    # Try numeric index (1-based)
+    try:
+        idx = int(tasklist) - 1
+        if 0 <= idx < len(all_lists):
+            tl = all_lists[idx]
+            return tl["id"], tl["title"]
+    except ValueError:
+        pass
+
+    # Try by name
+    for tl in all_lists:
+        if tl["title"] == tasklist:
+            return tl["id"], tl["title"]
+
+    # Try by ID
+    for tl in all_lists:
+        if tl["id"] == tasklist:
+            return tl["id"], tl["title"]
+
+    available = ", ".join(tl["title"] for tl in all_lists)
+    raise ValueError(f"Task list not found: {tasklist}. Available: {available}")
+
+
+def _safe_filename(title: str) -> str:
+    """Convert title to safe filename."""
+    safe = re.sub(r"[^\w\s-]", "", title)[:40].strip()
+    return re.sub(r"\s+", "_", safe)
+
+
+# =============================================================================
+# TaskList -- collection resource
+# =============================================================================
+
+
+class TaskList:
+    """Task list collection resource."""
+
+    name = "task-list"
+
+    def lists(self, out) -> None:
+        """List available task lists to file descriptor."""
+        tasklists = list_tasklists()
+        for tl in tasklists:
+            out.write(f"{tl['title']}\n")
+            out.write(f"  {tl['id']}\n")
+
+    def list(
+        self,
+        out,
+        *,
+        tasklist: str | None = None,
+        show_all: bool = False,
+        fmt: str = "md",
+    ) -> None:
+        """List tasks from a task list to stdout."""
+        tl_id, tl_title = resolve_tasklist_id(tasklist)
+        api_tasks = list_tasks(tl_id, show_completed=show_all)
+        items = [api_to_task(t, tl_id) for t in api_tasks]
+
+        out.write(f"# {tl_title}\n")
+        if fmt == "yaml":
+            out.write(format_tasks_yaml(items))
+        else:
+            out.write(format_tasks_md(items))
+
+    def clone(
+        self,
+        *,
+        tasklist: str | None = None,
+        output: Path | None = None,
+        fmt: str = "md",
+        show_all: bool = False,
+    ) -> Path:
+        """Clone task list to .tasks.gax.md or .tasks.gax.yaml file."""
+        tl_id, tl_title = resolve_tasklist_id(tasklist)
+        api_tasks = list_tasks(tl_id, show_completed=show_all)
+        items = [api_to_task(t, tl_id) for t in api_tasks]
+
+        ext = ".tasks.gax.yaml" if fmt == "yaml" else ".tasks.gax.md"
+        file_path = output or Path(f"{_safe_filename(tl_title)}{ext}")
+        if file_path.exists():
+            raise ValueError(f"File already exists: {file_path}")
+
+        self._write_list_file(file_path, tl_id, tl_title, items, fmt, show_all)
+        logger.info(f"Tasks: {len(items)}")
+        return file_path
+
+    def pull(self, path: Path) -> None:
+        """Pull latest tasks to existing list file."""
+        content = path.read_text()
+        if not content.startswith("---"):
+            raise ValueError("File must start with YAML header (---)")
+
+        header = yaml.safe_load(content.split("---", 2)[1])
+        tl_id = header.get("id", "")
+        tl_title = header.get("title", "")
+        fmt = header.get("format", "md")
+        show_all = header.get("show_all", False)
+
+        if not tl_id:
+            raise ValueError("No task list ID in file header")
+
+        api_tasks = list_tasks(tl_id, show_completed=show_all)
+        items = [api_to_task(t, tl_id) for t in api_tasks]
+
+        self._write_list_file(path, tl_id, tl_title, items, fmt, show_all)
+
+    def checkout(
+        self,
+        *,
+        tasklist: str | None = None,
+        output: Path | None = None,
+        show_all: bool = False,
+    ) -> tuple[int, int]:
+        """Checkout task list as folder of .task.gax.yaml files.
+
+        Returns (cloned, skipped).
+        """
+        tl_id, tl_title = resolve_tasklist_id(tasklist)
+        folder = output or Path(f"{_safe_filename(tl_title)}.tasks.gax.md.d")
+        folder.mkdir(parents=True, exist_ok=True)
+
+        api_tasks = list_tasks(tl_id, show_completed=show_all)
+        items = [api_to_task(t, tl_id) for t in api_tasks]
+
+        if not items:
+            return 0, 0
+
+        # Write .gax.yaml metadata
+        metadata = {
+            "type": "gax/task-checkout",
+            "tasklist_id": tl_id,
+            "title": tl_title,
+            "checked_out": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        }
+        metadata_path = folder / ".gax.yaml"
+        with open(metadata_path, "w") as f:
+            yaml.dump(
+                metadata,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+
+        # Get existing task IDs in folder
+        existing_ids = set()
+        for f_path in folder.glob("*.task.gax.yaml"):
+            try:
+                task_content = f_path.read_text()
+                parsed = yaml_to_task(task_content)
+                if parsed.id:
+                    existing_ids.add(parsed.id)
+            except Exception:
+                pass
+
+        cloned = 0
+        skipped = 0
+
+        for task in items:
+            if task.id in existing_ids:
+                skipped += 1
+                continue
+
+            filename = f"{_safe_filename(task.title)}.task.gax.yaml"
+            file_path = folder / filename
+            if file_path.exists():
+                filename = f"{_safe_filename(task.title)}_{task.id[:8]}.task.gax.yaml"
+                file_path = folder / filename
+
+            content = task_to_yaml(task)
+            file_path.write_text(content)
+            cloned += 1
+            logger.info(f"Writing {filename}")
+
+        return cloned, skipped
+
+    def _write_list_file(
+        self,
+        path: Path,
+        tl_id: str,
+        tl_title: str,
+        items: list[TaskItem],
+        fmt: str,
+        show_all: bool,
+    ) -> None:
+        """Write task list file with header and formatted body."""
+        header: dict[str, Any] = {
+            "type": "gax/task-list",
+            "id": tl_id,
+            "title": tl_title,
+            "format": fmt,
+            "synced": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        if show_all:
+            header["show_all"] = True
+
+        if fmt == "yaml":
+            body = format_tasks_yaml(items)
+        else:
+            body = format_tasks_md(items)
+
+        with open(path, "w") as f:
+            f.write("---\n")
+            yaml.dump(
+                header,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+            f.write("---\n")
+            f.write(body)
+
+
+# =============================================================================
+# Task(Resource) -- single task (clone/new/pull/diff/push/done/delete)
+# =============================================================================
+
+
+class Task(Resource):
+    """Google Tasks single-task resource."""
+
+    name = "task"
+
+    def clone(
+        self,
+        task_id: str,
+        *,
+        tasklist: str | None = None,
+        output: Path | None = None,
+        **kw,
+    ) -> Path:
+        """Clone a single task to a .task.gax.yaml file."""
+        tl_id, _tl_title = resolve_tasklist_id(tasklist)
+        api_task = get_task(tl_id, task_id)
+        task = api_to_task(api_task, tl_id)
+
+        if not output:
+            output = Path(f"{_safe_filename(task.title)}.task.gax.yaml")
+
+        if output.exists():
+            raise ValueError(f"File already exists: {output}")
+
+        content = task_to_yaml(task)
+        output.write_text(content)
+        return output
+
+    def new(
+        self,
+        title: str,
+        *,
+        tasklist: str | None = None,
+        output: Path | None = None,
+    ) -> Path:
+        """Create a new task on Google and write local .task.gax.yaml file."""
+        tl_id, _tl_title = resolve_tasklist_id(tasklist)
+
+        body = {"title": title, "status": "needsAction"}
+        result = create_task(tl_id, body)
+
+        task = api_to_task(result, tl_id)
+
+        file_path = output or Path(f"{_safe_filename(title)}.task.gax.yaml")
+        content = task_to_yaml(task)
+        file_path.write_text(content)
+        return file_path
+
+    def pull(self, path: Path, **kw) -> None:
+        """Pull latest task data from API."""
+        content = path.read_text()
+        local = yaml_to_task(content)
+
+        if not local.id:
+            raise ValueError("Task has no ID (not yet pushed upstream)")
+
+        api_task = get_task(local.tasklist, local.id)
+        updated = api_to_task(api_task, local.tasklist)
+
+        new_content = task_to_yaml(updated)
+        path.write_text(new_content)
+
+    def diff(self, path: Path, **kw) -> str | None:
+        """Preview changes between local task file and remote.
+
+        Returns a human-readable diff string, or None if no changes.
+        For new tasks (no id), returns a summary of what will be created.
+        """
+        content = path.read_text()
+        local = yaml_to_task(content)
+
+        if not local.id:
+            parts = [f"New task: {local.title}"]
+            if local.due:
+                parts.append(f"due: {local.due}")
+            return "\n".join(parts)
+
+        api_task = get_task(local.tasklist, local.id)
+        remote = api_to_task(api_task, local.tasklist)
+
+        fields = [
+            ("title", local.title, remote.title),
+            ("status", local.status, remote.status),
+            ("due", local.due, remote.due),
+            ("notes", local.notes, remote.notes),
+        ]
+
+        lines = []
+        for name, local_val, remote_val in fields:
+            if local_val != remote_val:
+                lines.append(f"{name}: {remote_val} -> {local_val}")
+
+        return "\n".join(lines) if lines else None
+
+    def push(self, path: Path, **kw) -> str:
+        """Push local task changes to API. Returns task title."""
+        content = path.read_text()
+        local = yaml_to_task(content)
+
+        body = task_to_api_body(local)
+
+        if local.id:
+            update_task(local.tasklist, local.id, body)
+            return local.title
+        else:
+            tl_id = local.tasklist
+            if not tl_id:
+                tl_id, _ = resolve_tasklist_id(None)
+
+            result = create_task(tl_id, body, parent=local.parent)
+
+            # Update local file with new ID
+            local.id = result["id"]
+            local.tasklist = tl_id
+            local.source = result.get("selfLink", "")
+            local.synced = datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+
+            new_content = task_to_yaml(local)
+            path.write_text(new_content)
+
+            return local.title
+
+    def done(self, path: Path) -> str:
+        """Mark task as completed and push. Returns task title."""
+        content = path.read_text()
+        local = yaml_to_task(content)
+
+        local.status = "completed"
+        local.completed = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+        # Write updated status locally
+        path.write_text(task_to_yaml(local))
+
+        # Push to API
+        if local.id:
+            body = task_to_api_body(local)
+            update_task(local.tasklist, local.id, body)
+
+        return local.title
+
+    def delete(self, path: Path) -> str:
+        """Delete task from Google and local file. Returns task title."""
+        content = path.read_text()
+        local = yaml_to_task(content)
+
+        if not local.id:
+            raise ValueError("Task has no ID (not on Google)")
+
+        delete_task(local.tasklist, local.id)
+        path.unlink()
+        return local.title

--- a/tests/test_gtask.py
+++ b/tests/test_gtask.py
@@ -1,0 +1,430 @@
+"""Tests for gax.gtask -- Google Tasks sync."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gax.gtask import (
+    TaskItem,
+    api_to_task,
+    task_to_api_body,
+    task_to_yaml,
+    yaml_to_task,
+    format_tasks_md,
+    parse_tasks_md,
+    format_tasks_yaml,
+    Task,
+)
+
+
+# =============================================================================
+# Sample data
+# =============================================================================
+
+SAMPLE_API_TASK = {
+    "id": "MTIzNDU2Nzg5",
+    "title": "Buy groceries",
+    "status": "needsAction",
+    "due": "2026-04-21T00:00:00.000Z",
+    "notes": "Milk, eggs, bread.",
+    "updated": "2026-04-18T14:30:00.000Z",
+    "selfLink": "https://www.googleapis.com/tasks/v1/lists/TL1/tasks/MTIzNDU2Nzg5",
+    "position": "00000000000000000001",
+}
+
+SAMPLE_API_COMPLETED = {
+    "id": "MTIzNDU2Nzk5",
+    "title": "Write ADR",
+    "status": "completed",
+    "due": "2026-04-20T00:00:00.000Z",
+    "completed": "2026-04-19T15:30:00.000Z",
+    "updated": "2026-04-19T15:30:00.000Z",
+    "selfLink": "https://www.googleapis.com/tasks/v1/lists/TL1/tasks/MTIzNDU2Nzk5",
+    "position": "00000000000000000002",
+}
+
+SAMPLE_API_SUBTASK = {
+    "id": "SUB1",
+    "title": "Milk",
+    "status": "needsAction",
+    "parent": "MTIzNDU2Nzg5",
+    "selfLink": "https://www.googleapis.com/tasks/v1/lists/TL1/tasks/SUB1",
+    "position": "00000000000000000001",
+}
+
+
+# =============================================================================
+# Inverse pair: API <-> TaskItem
+# =============================================================================
+
+
+class TestTaskApiRoundTrip:
+    """Tests for api_to_task / task_to_api_body inverse pair."""
+
+    def test_basic_fields(self):
+        """API task dict converts to TaskItem with correct fields."""
+        task = api_to_task(SAMPLE_API_TASK, "TL1")
+
+        assert task.id == "MTIzNDU2Nzg5"
+        assert task.tasklist == "TL1"
+        assert task.title == "Buy groceries"
+        assert task.status == "needsAction"
+        assert task.due == "2026-04-21"  # date-only, no time
+        assert task.notes == "Milk, eggs, bread."
+        assert task.position == "00000000000000000001"
+        assert task.synced  # should be set
+
+    def test_due_date_normalization(self):
+        """API's RFC 3339 due date is stored as date-only."""
+        task = api_to_task(SAMPLE_API_TASK, "TL1")
+        assert task.due == "2026-04-21"
+        assert "T" not in task.due
+
+    def test_completed_task(self):
+        """Completed task has status and timestamp."""
+        task = api_to_task(SAMPLE_API_COMPLETED, "TL1")
+        assert task.status == "completed"
+        assert task.completed == "2026-04-19T15:30:00.000Z"
+
+    def test_subtask(self):
+        """Subtask has parent field set."""
+        task = api_to_task(SAMPLE_API_SUBTASK, "TL1")
+        assert task.parent == "MTIzNDU2Nzg5"
+
+    def test_empty_task(self):
+        """Minimal API response converts without error."""
+        task = api_to_task({"id": "X", "title": "Empty"}, "TL1")
+        assert task.id == "X"
+        assert task.title == "Empty"
+        assert task.due == ""
+        assert task.notes == ""
+
+    def test_api_body_includes_pushable_fields(self):
+        """task_to_api_body includes title, status, due, notes."""
+        task = api_to_task(SAMPLE_API_TASK, "TL1")
+        body = task_to_api_body(task)
+
+        assert body["title"] == "Buy groceries"
+        assert body["status"] == "needsAction"
+        assert body["due"] == "2026-04-21T00:00:00.000Z"
+        assert body["notes"] == "Milk, eggs, bread."
+
+    def test_api_body_excludes_readonly(self):
+        """task_to_api_body excludes id, completed, updated, position."""
+        task = api_to_task(SAMPLE_API_COMPLETED, "TL1")
+        body = task_to_api_body(task)
+
+        assert "id" not in body
+        assert "completed" not in body
+        assert "updated" not in body
+        assert "position" not in body
+
+    def test_api_body_omits_empty_optional(self):
+        """Empty due and notes are omitted from API body."""
+        task = api_to_task({"id": "X", "title": "No extras"}, "TL1")
+        body = task_to_api_body(task)
+
+        assert "due" not in body
+        assert "notes" not in body
+        assert body["title"] == "No extras"
+
+
+# =============================================================================
+# Split YAML format
+# =============================================================================
+
+
+class TestTaskYamlRoundTrip:
+    """Tests for task_to_yaml / yaml_to_task."""
+
+    def test_round_trip(self):
+        """Full task round-trips through YAML."""
+        original = api_to_task(SAMPLE_API_TASK, "TL1")
+        yaml_str = task_to_yaml(original)
+        parsed = yaml_to_task(yaml_str)
+
+        assert parsed.id == original.id
+        assert parsed.tasklist == original.tasklist
+        assert parsed.title == original.title
+        assert parsed.status == original.status
+        assert parsed.due == original.due
+        assert parsed.notes == original.notes
+
+    def test_split_structure(self):
+        """YAML output has header (gax metadata) and body (task data)."""
+        task = api_to_task(SAMPLE_API_TASK, "TL1")
+        yaml_str = task_to_yaml(task)
+
+        parts = yaml_str.split("---", 2)
+        assert len(parts) == 3
+
+        # Header should have gax fields
+        assert "type:" in parts[1]
+        assert "gax/task" in parts[1]
+        assert "id:" in parts[1]
+        assert "tasklist:" in parts[1]
+
+        # Body should have task data
+        assert "title:" in parts[2]
+        assert "status:" in parts[2]
+
+        # Title should NOT be in header
+        assert "Buy groceries" not in parts[1]
+        assert "Buy groceries" in parts[2]
+
+    def test_minimal_task(self):
+        """Task with only required fields round-trips."""
+        task = TaskItem(
+            id="X", tasklist="TL1", source="", synced="", title="Simple"
+        )
+        yaml_str = task_to_yaml(task)
+        parsed = yaml_to_task(yaml_str)
+
+        assert parsed.title == "Simple"
+        assert parsed.due == ""
+        assert parsed.notes == ""
+
+    def test_notes_with_newlines(self):
+        """Multi-line notes round-trip correctly."""
+        task = TaskItem(
+            id="X",
+            tasklist="TL1",
+            source="",
+            synced="",
+            title="Multi",
+            notes="Line 1\nLine 2\nLine 3\n",
+        )
+        yaml_str = task_to_yaml(task)
+        parsed = yaml_to_task(yaml_str)
+
+        assert parsed.notes == "Line 1\nLine 2\nLine 3\n"
+
+    def test_invalid_no_frontmatter(self):
+        """Missing --- raises ValueError."""
+        with pytest.raises(ValueError, match="frontmatter"):
+            yaml_to_task("title: foo\nstatus: needsAction\n")
+
+    def test_invalid_wrong_type(self):
+        """Wrong type field raises ValueError."""
+        content = "---\ntype: gax/cal\nid: X\n---\ntitle: foo\n"
+        with pytest.raises(ValueError, match="gax/task"):
+            yaml_to_task(content)
+
+
+# =============================================================================
+# Markdown checkbox format
+# =============================================================================
+
+
+class TestTaskListFormatMd:
+    """Tests for format_tasks_md / parse_tasks_md."""
+
+    def test_format_basic(self):
+        """Root tasks formatted as checkboxes."""
+        tasks = [
+            TaskItem("A", "TL1", "", "", "Task A", "needsAction"),
+            TaskItem("B", "TL1", "", "", "Task B", "completed"),
+        ]
+        result = format_tasks_md(tasks)
+
+        assert "- [ ] Task A `A`" in result
+        assert "- [x] Task B `B`" in result
+
+    def test_format_with_due(self):
+        """Due date appended to checkbox line."""
+        tasks = [
+            TaskItem(
+                "A", "TL1", "", "", "Task A", "needsAction", due="2026-04-21"
+            ),
+        ]
+        result = format_tasks_md(tasks)
+        assert "due:2026-04-21" in result
+
+    def test_format_subtasks(self):
+        """Subtasks indented under parent."""
+        tasks = [
+            TaskItem("P", "TL1", "", "", "Parent", "needsAction"),
+            TaskItem("C", "TL1", "", "", "Child", "needsAction", parent="P"),
+        ]
+        result = format_tasks_md(tasks)
+
+        lines = result.strip().split("\n")
+        assert lines[0].startswith("- [ ] Parent")
+        assert lines[1].startswith("  - [ ] Child")
+
+    def test_parse_basic(self):
+        """Parse checkboxes back to task dicts."""
+        content = "- [ ] Task A `A1` due:2026-04-21\n- [x] Task B `B1`\n"
+        parsed = parse_tasks_md(content)
+
+        assert len(parsed) == 2
+        assert parsed[0]["title"] == "Task A"
+        assert parsed[0]["id"] == "A1"
+        assert parsed[0]["status"] == "needsAction"
+        assert parsed[0]["due"] == "2026-04-21"
+        assert parsed[1]["title"] == "Task B"
+        assert parsed[1]["status"] == "completed"
+
+    def test_parse_subtask(self):
+        """Indented items parsed as subtasks."""
+        content = "- [ ] Parent `P`\n  - [ ] Child `C`\n"
+        parsed = parse_tasks_md(content)
+
+        assert len(parsed) == 2
+        assert parsed[0]["is_subtask"] is False
+        assert parsed[1]["is_subtask"] is True
+
+    def test_parse_new_task_no_id(self):
+        """Lines without backtick ID are new tasks."""
+        content = "- [ ] New task\n"
+        parsed = parse_tasks_md(content)
+
+        assert len(parsed) == 1
+        assert parsed[0]["title"] == "New task"
+        assert parsed[0]["id"] == ""
+
+    def test_round_trip(self):
+        """Format -> parse preserves essential data."""
+        tasks = [
+            TaskItem("A", "TL1", "", "", "Task A", "needsAction", due="2026-04-21"),
+            TaskItem("B", "TL1", "", "", "Task B", "completed"),
+        ]
+        md = format_tasks_md(tasks)
+        parsed = parse_tasks_md(md)
+
+        assert len(parsed) == 2
+        assert parsed[0]["title"] == "Task A"
+        assert parsed[0]["id"] == "A"
+        assert parsed[0]["due"] == "2026-04-21"
+        assert parsed[1]["title"] == "Task B"
+        assert parsed[1]["status"] == "completed"
+
+
+# =============================================================================
+# YAML list format
+# =============================================================================
+
+
+class TestTaskListFormatYaml:
+    """Tests for format_tasks_yaml."""
+
+    def test_format_basic(self):
+        """Root tasks formatted as YAML list."""
+        tasks = [
+            TaskItem(
+                "A", "TL1", "", "", "Task A", "needsAction", due="2026-04-21"
+            ),
+        ]
+        result = format_tasks_yaml(tasks)
+
+        assert "title: Task A" in result
+        assert "id: A" in result
+        assert "due: '2026-04-21'" in result or "due: 2026-04-21" in result
+
+    def test_format_subtasks(self):
+        """Subtasks nested under parent."""
+        tasks = [
+            TaskItem("P", "TL1", "", "", "Parent", "needsAction"),
+            TaskItem("C", "TL1", "", "", "Child", "needsAction", parent="P"),
+        ]
+        result = format_tasks_yaml(tasks)
+
+        assert "subtasks:" in result
+        assert "Child" in result
+
+    def test_format_omits_empty(self):
+        """Empty optional fields omitted."""
+        tasks = [TaskItem("A", "TL1", "", "", "Task A", "needsAction")]
+        result = format_tasks_yaml(tasks)
+
+        assert "notes:" not in result
+        assert "completed:" not in result
+
+
+# =============================================================================
+# Task.diff()
+# =============================================================================
+
+
+class TestTaskDiff:
+    """Tests for Task.diff() with mocked API."""
+
+    def test_new_task_returns_summary(self, tmp_path):
+        """No ID returns creation summary."""
+        task = TaskItem("", "TL1", "", "", "New task", due="2026-04-21")
+        path = tmp_path / "new.task.gax.yaml"
+        path.write_text(task_to_yaml(task))
+
+        result = Task().diff(path)
+        assert "New task" in result
+        assert "2026-04-21" in result
+
+    @patch("gax.gtask.get_task")
+    @patch("gax.gtask.api_to_task")
+    def test_no_changes_returns_none(self, mock_api_to, mock_get, tmp_path):
+        """Identical local/remote returns None."""
+        task = TaskItem(
+            "A", "TL1", "", "", "Same", "needsAction", due="2026-04-21"
+        )
+        path = tmp_path / "same.task.gax.yaml"
+        path.write_text(task_to_yaml(task))
+
+        mock_get.return_value = {}
+        mock_api_to.return_value = TaskItem(
+            "A", "TL1", "", "", "Same", "needsAction", due="2026-04-21"
+        )
+
+        result = Task().diff(path)
+        assert result is None
+
+    @patch("gax.gtask.get_task")
+    @patch("gax.gtask.api_to_task")
+    def test_field_changes(self, mock_api_to, mock_get, tmp_path):
+        """Changed fields shown in diff output."""
+        local = TaskItem(
+            "A", "TL1", "", "", "Updated title", "completed", due="2026-04-22"
+        )
+        path = tmp_path / "changed.task.gax.yaml"
+        path.write_text(task_to_yaml(local))
+
+        mock_get.return_value = {}
+        mock_api_to.return_value = TaskItem(
+            "A", "TL1", "", "", "Original title", "needsAction", due="2026-04-21"
+        )
+
+        result = Task().diff(path)
+        assert "title:" in result
+        assert "status:" in result
+        assert "due:" in result
+
+
+# =============================================================================
+# Task.done()
+# =============================================================================
+
+
+class TestTaskDone:
+    """Tests for Task.done() shortcut."""
+
+    @patch("gax.gtask.update_task")
+    def test_done_sets_completed_and_pushes(self, mock_update, tmp_path):
+        """done() sets status=completed, writes file, calls API."""
+        task = TaskItem("A", "TL1", "", "", "My task", "needsAction")
+        path = tmp_path / "task.task.gax.yaml"
+        path.write_text(task_to_yaml(task))
+
+        title = Task().done(path)
+
+        assert title == "My task"
+
+        # File should be updated
+        updated = yaml_to_task(path.read_text())
+        assert updated.status == "completed"
+        assert updated.completed  # timestamp set
+
+        # API should be called
+        mock_update.assert_called_once()
+        call_args = mock_update.call_args
+        assert call_args[0][0] == "TL1"  # tasklist
+        assert call_args[0][1] == "A"  # task_id
+        assert call_args[0][2]["status"] == "completed"


### PR DESCRIPTION
## Summary

- New `gax/gtask.py` module with TaskItem dataclass, API helpers, split YAML format, markdown/YAML list formats
- 10 CLI commands: `gax task lists/list/clone/checkout/pull/new/diff/push/done/delete`
- Unified pull/push dispatch in cli_helper.py
- Tasks OAuth scope added to auth.py
- Fix TabInfo subscript error in doc clone hint (regression from #38)
- Fix per-tab lists lookup for ordered list rendering (regression from #36)
- 28 new tests, 340 total passing

Closes #34 (ADR 031)

## Test plan

- [x] `make test` — 340 unit tests pass
- [x] e2e and roundtrip tests pass (both previously failing, now fixed)
- [x] `gax task --help` shows all 10 commands
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)