### PR TITLE
feat: calendar YAML split and contacts checkout

### DIFF
--- a/gax/cli.py
+++ b/gax/cli.py
@@ -1084,6 +1084,34 @@ def contacts_push(file, yes):
         sys.exit(1)
 
 
+@contacts.command("checkout")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help="Output folder (default: contacts.contacts.gax.md.d)",
+)
+def contacts_checkout(output):
+    """Checkout contacts as individual files into a folder.
+
+    Creates one .contact.gax.yaml file per contact for easy per-contact
+    editing and diffing.
+    """
+    try:
+        from .ui import success
+
+        cloned, skipped = Contacts().checkout(output=output)
+        parts = [f"{cloned} contacts"]
+        if skipped:
+            parts.append(f"({skipped} skipped)")
+        success(f"Checked out {' '.join(parts)}")
+    except ValueError as e:
+        from .ui import error
+
+        error(str(e))
+        sys.exit(1)
+
+
 # =============================================================================
 # File commands (Google Drive)
 # =============================================================================

--- a/gax/cli_helper.py
+++ b/gax/cli_helper.py
@@ -105,6 +105,8 @@ def _detect_file_type(file_path: Path) -> str | None:
         return "gax/form"
     if name.endswith(".slides.gax.md"):
         return "gax/slides"
+    if name.endswith(".contact.gax.yaml"):
+        return "gax/contact"
     if ".contacts." in name or name.endswith(".contacts.gax.md"):
         return "gax/contacts"
     # Mailbox/list files often don't have specific extension, just .gax.md
@@ -206,6 +208,13 @@ def _pull_folder(
                     TaskSingleResource().pull(task_file)
                 except ValueError:
                     pass
+            return True, "updated"
+
+        elif checkout_type == "gax/contacts-checkout":
+            # Contacts checkouts pull in-place
+            if scratch_path.exists():
+                shutil.rmtree(scratch_path)
+            Contacts().pull_checkout(folder_path)
             return True, "updated"
 
         else:
@@ -577,6 +586,18 @@ def _push_folder(
             p.push(folder_path)
             return True, "pushed"
 
+        elif checkout_type == "gax/contacts-checkout":
+            c = Contacts()
+            diff_text = c.diff_checkout(folder_path)
+            if diff_text is None:
+                return True, "no changes"
+            if not yes:
+                click.echo("\n" + diff_text)
+                if not click.confirm("\nPush these changes?"):
+                    return False, "cancelled"
+            c.push_checkout(folder_path)
+            return True, "pushed"
+
         else:
             return False, f"Push not supported for checkout type: {checkout_type}"
 
@@ -684,6 +705,27 @@ def _pull_file(file_path: Path, verbose: bool = False) -> tuple[bool, str]:
             try:
                 Form().pull(file_path)
                 return True, "updated"
+            except ValueError as e:
+                return False, str(e)
+
+        elif file_type == "gax/contact":
+            try:
+                from .contacts import yaml_to_contact, contact_to_yaml
+
+                c = yaml_to_contact(file_path.read_text(encoding="utf-8"))
+                rn = c.get("resourceName", "")
+                if not rn:
+                    return False, "Contact has no resourceName"
+                # Re-fetch and overwrite
+                from .contacts import fetch_contacts, api_to_contact
+
+                raw, groups = fetch_contacts()
+                for raw_c in raw:
+                    if raw_c.get("resourceName") == rn:
+                        updated = api_to_contact(raw_c, groups)
+                        file_path.write_text(contact_to_yaml(updated), encoding="utf-8")
+                        return True, "updated"
+                return False, f"Contact {rn} not found remotely"
             except ValueError as e:
                 return False, str(e)
 

--- a/gax/contacts.py
+++ b/gax/contacts.py
@@ -35,10 +35,12 @@ Additional notes specific to contacts:
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+import yaml
 from googleapiclient.discovery import build
 
 from .auth import get_authenticated_credentials
@@ -363,6 +365,84 @@ def format_markdown(contacts: list[dict]) -> str:
 
 
 # =============================================================================
+# Individual contact file format — split header/body YAML (.contact.gax.yaml)
+#
+# contact_to_yaml and yaml_to_contact are an inverse pair.
+# =============================================================================
+
+
+def contact_to_yaml(contact: dict) -> str:
+    """Serialize a normalized contact dict to split YAML (header + body)."""
+    header: dict = {
+        "type": "gax/contact",
+        "resourceName": contact.get("resourceName", ""),
+        "synced": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    body: dict = {}
+    for field in CONTACT_BODY_FIELDS:
+        val = contact.get(field)
+        if val:  # omit empty strings and empty lists
+            body[field] = val
+
+    header_str = yaml.dump(
+        header, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+    body_str = yaml.dump(
+        body, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+
+    return f"---\n{header_str}---\n{body_str}"
+
+
+CONTACT_BODY_FIELDS = [
+    "name",
+    "givenName",
+    "familyName",
+    "email",
+    "phone",
+    "organization",
+    "title",
+    "department",
+    "address",
+    "birthday",
+    "notes",
+    "nickname",
+    "website",
+    "labels",
+]
+
+
+def yaml_to_contact(content: str) -> dict:
+    """Parse split YAML content to a normalized contact dict."""
+    if not content.startswith("---"):
+        raise ValueError("Expected YAML frontmatter (---)")
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError("Invalid split YAML format")
+
+    header = yaml.safe_load(parts[1])
+    body = yaml.safe_load(parts[2])
+    data = {**header, **(body or {})}
+
+    # Build normalized contact dict with defaults
+    contact = {"resourceName": data.get("resourceName", "")}
+    for field in CONTACT_BODY_FIELDS:
+        if field in LIST_FIELDS:
+            contact[field] = data.get(field, [])
+        else:
+            contact[field] = data.get(field, "")
+    return contact
+
+
+def _safe_filename(name: str) -> str:
+    """Create a filesystem-safe filename from a contact name."""
+    safe = re.sub(r"[^\w\s-]", "", name)[:40].strip()
+    return re.sub(r"\s+", "_", safe) or "unnamed"
+
+
+# =============================================================================
 # Comparison helpers — diff logic for local vs remote contacts.
 # =============================================================================
 
@@ -574,7 +654,157 @@ class Contacts(Resource):
             raise ValueError("push only works with JSONL format")
 
         local_contacts = parse_jsonl_body(body)
+        self._push_contacts(local_contacts)
 
+    # ── Checkout operations ──────────────────────────────────────────────
+
+    def checkout(self, *, output: Path | None = None, **kw) -> tuple[int, int]:
+        """Checkout contacts as individual .contact.gax.yaml files.
+
+        Returns (cloned, skipped).
+        """
+        logger.info("Fetching contacts...")
+        normalized, _ = self._fetch_and_normalize()
+
+        folder = output or Path("contacts.contacts.gax.md.d")
+        folder.mkdir(parents=True, exist_ok=True)
+
+        # Write .gax.yaml metadata
+        meta = {
+            "type": "gax/contacts-checkout",
+            "checked_out": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        (folder / ".gax.yaml").write_text(
+            yaml.dump(meta, default_flow_style=False, sort_keys=False)
+        )
+
+        # Get existing resourceNames in folder
+        existing_ids: set[str] = set()
+        for f in folder.glob("*.contact.gax.yaml"):
+            try:
+                c = yaml_to_contact(f.read_text(encoding="utf-8"))
+                if c.get("resourceName"):
+                    existing_ids.add(c["resourceName"])
+            except Exception:
+                pass
+
+        cloned = 0
+        skipped = 0
+
+        for contact in normalized:
+            resource_name = contact.get("resourceName", "")
+            if resource_name in existing_ids:
+                skipped += 1
+                continue
+
+            name = contact.get("name", "unnamed")
+            filename = f"{_safe_filename(name)}.contact.gax.yaml"
+            file_path = folder / filename
+
+            # Handle filename collisions
+            if file_path.exists():
+                suffix = (
+                    resource_name.rsplit("/", 1)[-1][:8]
+                    if resource_name
+                    else str(cloned)
+                )
+                filename = f"{_safe_filename(name)}_{suffix}.contact.gax.yaml"
+                file_path = folder / filename
+
+            file_path.write_text(contact_to_yaml(contact), encoding="utf-8")
+            cloned += 1
+            logger.info(f"Writing {filename}")
+
+        logger.info(f"Contacts: {cloned} cloned, {skipped} skipped")
+        return cloned, skipped
+
+    def pull_checkout(self, folder: Path, **kw) -> None:
+        """Pull latest contacts into checkout folder, updating/adding/removing files."""
+        logger.info("Fetching contacts...")
+        normalized, _ = self._fetch_and_normalize()
+        remote_by_id = {
+            c["resourceName"]: c for c in normalized if c.get("resourceName")
+        }
+
+        # Scan existing files
+        local_files: dict[str, Path] = {}  # resourceName -> file path
+        for f in folder.glob("*.contact.gax.yaml"):
+            try:
+                c = yaml_to_contact(f.read_text(encoding="utf-8"))
+                rn = c.get("resourceName", "")
+                if rn:
+                    local_files[rn] = f
+            except Exception:
+                pass
+
+        # Update existing and remove stale
+        for rn, file_path in local_files.items():
+            if rn in remote_by_id:
+                file_path.write_text(
+                    contact_to_yaml(remote_by_id[rn]), encoding="utf-8"
+                )
+            else:
+                file_path.unlink()
+                logger.info(f"Removed: {file_path.name}")
+
+        # Add new contacts
+        added = 0
+        for rn, contact in remote_by_id.items():
+            if rn not in local_files:
+                name = contact.get("name", "unnamed")
+                filename = f"{_safe_filename(name)}.contact.gax.yaml"
+                file_path = folder / filename
+                if file_path.exists():
+                    suffix = rn.rsplit("/", 1)[-1][:8]
+                    filename = f"{_safe_filename(name)}_{suffix}.contact.gax.yaml"
+                    file_path = folder / filename
+                file_path.write_text(contact_to_yaml(contact), encoding="utf-8")
+                added += 1
+                logger.info(f"Added: {filename}")
+
+        # Update metadata
+        meta = {
+            "type": "gax/contacts-checkout",
+            "checked_out": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        (folder / ".gax.yaml").write_text(
+            yaml.dump(meta, default_flow_style=False, sort_keys=False)
+        )
+
+        logger.info(
+            f"Updated: {len(local_files)} existing, {added} added, "
+            f"{len(local_files) - sum(1 for rn in local_files if rn in remote_by_id)} removed"
+        )
+
+    def diff_checkout(self, folder: Path, **kw) -> str | None:
+        """Preview changes between checkout folder and remote contacts."""
+        local_contacts = self._read_checkout_contacts(folder)
+
+        logger.info("Fetching remote contacts...")
+        remote_contacts, _ = self._fetch_and_normalize()
+
+        creates, updates, deletes = compare_contacts(local_contacts, remote_contacts)
+        return format_diff_summary(creates, updates, deletes) or None
+
+    def push_checkout(self, folder: Path, **kw) -> None:
+        """Push checkout folder contacts to Google."""
+        local_contacts = self._read_checkout_contacts(folder)
+        self._push_contacts(local_contacts)
+
+    # ── Private helpers ──────────────────────────────────────────────────
+
+    def _read_checkout_contacts(self, folder: Path) -> list[dict]:
+        """Read all .contact.gax.yaml files from a checkout folder."""
+        contacts = []
+        for f in sorted(folder.glob("*.contact.gax.yaml")):
+            try:
+                contacts.append(yaml_to_contact(f.read_text(encoding="utf-8")))
+            except Exception as e:
+                logger.warning(f"Skipping {f.name}: {e}")
+        return contacts
+
+    def _push_contacts(self, local_contacts: list[dict]) -> None:
+        """Push a list of normalized contacts to Google. Shared by push() and push_checkout()."""
         logger.info("Fetching remote contacts...")
         service = get_service()
         raw_remote, groups = fetch_contacts(service=service)

--- a/gax/gcal.py
+++ b/gax/gcal.py
@@ -457,13 +457,19 @@ def format_events_tsv(events: list[dict], include_desc: bool = False) -> str:
 
 
 def event_to_yaml(event: CalendarEvent) -> str:
-    """Convert CalendarEvent to YAML file content."""
-    data = {
+    """Convert CalendarEvent to split YAML (header + body).
+
+    Header contains gax sync metadata; body contains user-editable event data.
+    """
+    header: dict[str, Any] = {
         "type": "gax/cal",
         "id": event.id,
         "calendar": event.calendar,
         "source": event.source,
         "synced": event.synced,
+    }
+
+    body: dict[str, Any] = {
         "title": event.title,
         "start": event.start,
         "end": event.end,
@@ -471,34 +477,40 @@ def event_to_yaml(event: CalendarEvent) -> str:
     }
 
     if event.location:
-        data["location"] = event.location
+        body["location"] = event.location
 
     if event.recurrence:
-        data["recurrence"] = event.recurrence
+        body["recurrence"] = event.recurrence
 
     if event.attendees:
-        data["attendees"] = event.attendees
+        body["attendees"] = event.attendees
 
-    data["status"] = event.status
+    body["status"] = event.status
 
     if event.conference:
-        data["conference"] = {
+        body["conference"] = {
             "type": event.conference.type,
             "uri": event.conference.uri,
         }
 
     if event.description:
-        data["description"] = event.description
+        body["description"] = event.description
 
-    return (
-        "---\n"
-        + yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
-        + "---\n"
+    header_str = yaml.dump(
+        header, default_flow_style=False, allow_unicode=True, sort_keys=False
     )
+    body_str = yaml.dump(
+        body, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+
+    return f"---\n{header_str}---\n{body_str}"
 
 
 def yaml_to_event(content: str) -> CalendarEvent:
-    """Parse YAML file content to CalendarEvent."""
+    """Parse split YAML (header + body) to CalendarEvent.
+
+    Also handles legacy single-section format for backward compatibility.
+    """
     if not content.startswith("---"):
         raise ValueError("Expected YAML frontmatter")
 
@@ -506,8 +518,10 @@ def yaml_to_event(content: str) -> CalendarEvent:
     if len(parts) < 3:
         raise ValueError("Invalid YAML frontmatter format")
 
-    yaml_content = parts[1]
-    data = yaml.safe_load(yaml_content)
+    header = yaml.safe_load(parts[1])
+    body = yaml.safe_load(parts[2])
+    # Merge header and body — handles both split and legacy single-section format
+    data = {**header, **(body or {})}
 
     conference = None
     if "conference" in data:

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,8 +1,15 @@
 """Unit tests for contacts module — no API calls needed."""
 
+from unittest.mock import patch
+
+import yaml
+
 from gax.contacts import (
+    Contacts,
     api_to_contact,
     contact_to_api,
+    contact_to_yaml,
+    yaml_to_contact,
     contact_diff,
     compare_contacts,
     format_jsonl,
@@ -189,3 +196,252 @@ class TestFileFormat:
         assert parsed_header.count == 42
         assert parsed_header.pulled == "2026-01-01T00:00:00Z"
         assert parsed_body.strip() == body
+
+
+# =============================================================================
+# Individual contact YAML round-trip: contact_to_yaml <-> yaml_to_contact
+# =============================================================================
+
+
+class TestContactYamlRoundTrip:
+    def test_round_trip(self):
+        normalized = api_to_contact(SAMPLE_API_CONTACT, SAMPLE_GROUPS)
+        yaml_content = contact_to_yaml(normalized)
+        parsed = yaml_to_contact(yaml_content)
+
+        assert parsed["resourceName"] == "people/c123"
+        assert parsed["name"] == "Alice Smith"
+        assert parsed["givenName"] == "Alice"
+        assert parsed["familyName"] == "Smith"
+        assert parsed["email"] == ["alice@example.com", "alice@work.com"]
+        assert parsed["phone"] == ["+1-555-0100"]
+        assert parsed["organization"] == "Acme Corp"
+        assert parsed["title"] == "Engineer"
+        assert parsed["birthday"] == "1990-03-15"
+        assert parsed["labels"] == ["Friends"]
+
+    def test_split_format(self):
+        """Header should contain metadata, body should contain contact data."""
+        contact = {"resourceName": "people/c1", "name": "Bob", "email": ["b@x.com"]}
+        content = contact_to_yaml(contact)
+
+        parts = content.split("---")
+        assert len(parts) == 3
+
+        header = yaml.safe_load(parts[1])
+        assert header["type"] == "gax/contact"
+        assert header["resourceName"] == "people/c1"
+        assert "name" not in header
+
+        body = yaml.safe_load(parts[2])
+        assert body["name"] == "Bob"
+        assert "type" not in body
+
+    def test_empty_fields_omitted(self):
+        """Empty strings and empty lists should not appear in body."""
+        contact = {
+            "resourceName": "people/c1",
+            "name": "Bob",
+            "email": [],
+            "phone": [],
+            "organization": "",
+            "labels": [],
+        }
+        content = contact_to_yaml(contact)
+        body = yaml.safe_load(content.split("---")[2])
+        assert "email" not in body
+        assert "phone" not in body
+        assert "organization" not in body
+
+    def test_invalid_format(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Expected YAML frontmatter"):
+            yaml_to_contact("not yaml")
+
+
+# =============================================================================
+# Contacts.checkout
+# =============================================================================
+
+
+SAMPLE_NORMALIZED = [
+    {
+        "resourceName": "people/c1",
+        "name": "Alice Smith",
+        "givenName": "Alice",
+        "familyName": "Smith",
+        "email": ["alice@x.com"],
+        "phone": [],
+        "organization": "",
+        "title": "",
+        "department": "",
+        "address": "",
+        "birthday": "",
+        "notes": "",
+        "nickname": "",
+        "website": "",
+        "labels": [],
+    },
+    {
+        "resourceName": "people/c2",
+        "name": "Bob Jones",
+        "givenName": "Bob",
+        "familyName": "Jones",
+        "email": ["bob@x.com"],
+        "phone": ["+1-555-0200"],
+        "organization": "Acme",
+        "title": "",
+        "department": "",
+        "address": "",
+        "birthday": "",
+        "notes": "",
+        "nickname": "",
+        "website": "",
+        "labels": [],
+    },
+]
+
+
+class TestContactsCheckout:
+    @patch("gax.contacts.fetch_contacts")
+    @patch("gax.contacts.fetch_contact_groups")
+    def test_checkout_creates_folder(self, mock_groups, mock_fetch, tmp_path):
+        mock_groups.return_value = {}
+        mock_fetch.return_value = (
+            [
+                {
+                    "resourceName": c["resourceName"],
+                    "names": [
+                        {
+                            "displayName": c["name"],
+                            "givenName": c["givenName"],
+                            "familyName": c["familyName"],
+                        }
+                    ],
+                    "emailAddresses": [{"value": e} for e in c["email"]],
+                }
+                for c in SAMPLE_NORMALIZED
+            ],
+            {},
+        )
+        # Use pre-normalized contacts via direct mock
+        with patch.object(
+            Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+        ):
+            output = tmp_path / "contacts.contacts.gax.md.d"
+            cloned, skipped = Contacts().checkout(output=output)
+
+            assert output.exists()
+            assert (output / ".gax.yaml").exists()
+            assert cloned == 2
+            assert skipped == 0
+
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_checkout_creates_contact_files(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+        Contacts().checkout(output=output)
+
+        files = sorted(output.glob("*.contact.gax.yaml"))
+        assert len(files) == 2
+
+        # Files should round-trip cleanly
+        for f in files:
+            c = yaml_to_contact(f.read_text())
+            assert c["resourceName"] in ("people/c1", "people/c2")
+
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_checkout_writes_metadata(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+        Contacts().checkout(output=output)
+
+        meta = yaml.safe_load((output / ".gax.yaml").read_text())
+        assert meta["type"] == "gax/contacts-checkout"
+        assert "checked_out" in meta
+
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_checkout_skips_existing(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+
+        # First checkout
+        Contacts().checkout(output=output)
+
+        # Second checkout should skip all
+        cloned, skipped = Contacts().checkout(output=output)
+        assert cloned == 0
+        assert skipped == 2
+
+
+# =============================================================================
+# Contacts.pull_checkout
+# =============================================================================
+
+
+class TestCheckoutPull:
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_pull_removes_stale_contacts(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+
+        # Checkout with 2 contacts
+        Contacts().checkout(output=output)
+        assert len(list(output.glob("*.contact.gax.yaml"))) == 2
+
+        # Remote now has only one contact
+        mock_fetch.return_value = (SAMPLE_NORMALIZED[:1], {})
+        Contacts().pull_checkout(output)
+
+        files = list(output.glob("*.contact.gax.yaml"))
+        assert len(files) == 1
+
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_pull_adds_new_contacts(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+
+        # Checkout with 2 contacts
+        Contacts().checkout(output=output)
+
+        # Remote now has 3 contacts
+        new_contact = {
+            **SAMPLE_NORMALIZED[0],
+            "resourceName": "people/c3",
+            "name": "Charlie Brown",
+        }
+        mock_fetch.return_value = (SAMPLE_NORMALIZED + [new_contact], {})
+        Contacts().pull_checkout(output)
+
+        files = list(output.glob("*.contact.gax.yaml"))
+        assert len(files) == 3
+
+    @patch.object(
+        Contacts, "_fetch_and_normalize", return_value=(SAMPLE_NORMALIZED, {})
+    )
+    def test_pull_updates_existing(self, mock_fetch, tmp_path):
+        output = tmp_path / "contacts.contacts.gax.md.d"
+
+        # Checkout
+        Contacts().checkout(output=output)
+
+        # Remote has updated name for c1
+        updated = [
+            {**SAMPLE_NORMALIZED[0], "name": "Alice Updated"},
+            SAMPLE_NORMALIZED[1],
+        ]
+        mock_fetch.return_value = (updated, {})
+        Contacts().pull_checkout(output)
+
+        # Find the file for people/c1 and verify
+        for f in output.glob("*.contact.gax.yaml"):
+            c = yaml_to_contact(f.read_text())
+            if c["resourceName"] == "people/c1":
+                assert c["name"] == "Alice Updated"
+                break

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -174,6 +174,64 @@ class TestEventYamlRoundTrip:
         assert parsed.conference is None
         assert parsed.attendees == []
 
+    def test_split_format_has_two_sections(self):
+        """New format should have header (metadata) and body (event data)."""
+        event = CalendarEvent(
+            id="evt123",
+            calendar="primary",
+            source="https://calendar.google.com/calendar/event?eid=evt123",
+            synced="2026-03-15T00:00:00Z",
+            title="Meeting",
+            start="2026-03-15T09:00:00+01:00",
+            end="2026-03-15T10:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+        yaml_content = event_to_yaml(event)
+
+        # Should have exactly two --- delimiters (header open + body separator)
+        parts = yaml_content.split("---")
+        assert len(parts) == 3  # ['', header, body]
+
+        # Header should contain metadata, not event data
+        import yaml
+
+        header = yaml.safe_load(parts[1])
+        assert header["type"] == "gax/cal"
+        assert header["id"] == "evt123"
+        assert "title" not in header
+        assert "start" not in header
+
+        # Body should contain event data, not metadata
+        body = yaml.safe_load(parts[2])
+        assert body["title"] == "Meeting"
+        assert body["start"] == "2026-03-15T09:00:00+01:00"
+        assert "type" not in body
+        assert "id" not in body
+
+    def test_legacy_single_section_format(self):
+        """Old format (all fields in one section) should still parse correctly."""
+        legacy = (
+            "---\n"
+            "type: gax/cal\n"
+            "id: evt_old\n"
+            "calendar: primary\n"
+            "source: https://calendar.google.com/calendar/event?eid=evt_old\n"
+            "synced: '2026-01-01T00:00:00Z'\n"
+            "title: Legacy Event\n"
+            "start: '2026-01-15T10:00:00+01:00'\n"
+            "end: '2026-01-15T11:00:00+01:00'\n"
+            "timezone: Europe/Berlin\n"
+            "location: Room 1\n"
+            "status: confirmed\n"
+            "---\n"
+        )
+        parsed = yaml_to_event(legacy)
+        assert parsed.id == "evt_old"
+        assert parsed.title == "Legacy Event"
+        assert parsed.start == "2026-01-15T10:00:00+01:00"
+        assert parsed.location == "Room 1"
+        assert parsed.timezone == "Europe/Berlin"
+
     def test_invalid_frontmatter(self):
         import pytest
 


### PR DESCRIPTION
## Summary

- **#40 Calendar YAML split**: `event_to_yaml()`/`yaml_to_event()` now use split header (sync metadata) + body (event data) format, matching the tasks pattern. Backward-compatible with old single-section files.
- **#39 Contacts checkout**: `gax contacts checkout` creates a `.contacts.gax.md.d/` folder with individual `.contact.gax.yaml` files. Supports pull (update/add/remove), diff, and push for checkout folders.

Closes #40, closes #39

## Test plan

- [x] Calendar YAML round-trip tests pass (29 tests)
- [x] Legacy single-section calendar format parses correctly
- [x] Contact YAML round-trip tests pass
- [x] Checkout creates folder with `.gax.yaml` metadata and per-contact files
- [x] Second checkout skips existing contacts
- [x] Pull removes stale, adds new, updates existing contacts
- [x] Full test suite passes (404 passed, 31 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)