### PR TITLE
feat: Add attachment support for draft push

### DIFF
--- a/gax/mail/draft.py
+++ b/gax/mail/draft.py
@@ -55,9 +55,13 @@ What we chose NOT to abstract:
 import base64
 import difflib
 import logging
+import mimetypes
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -92,6 +96,7 @@ class DraftHeader:
     in_reply_to: str = ""
     source: str = ""
     time: str = ""
+    attachments: list[str] = field(default_factory=list)
 
 
 # =============================================================================
@@ -114,6 +119,9 @@ def parse_draft(content: str) -> tuple[DraftHeader, str]:
     section = sections[0]
     h = section.headers
 
+    raw_atts = h.get("attachments", [])
+    attachments = [str(item) for item in raw_atts]
+
     header = DraftHeader(
         draft_id=h.get("draft_id", ""),
         message_id=h.get("message_id", ""),
@@ -125,6 +133,7 @@ def parse_draft(content: str) -> tuple[DraftHeader, str]:
         in_reply_to=h.get("in_reply_to", ""),
         source=h.get("source", ""),
         time=h.get("time", ""),
+        attachments=attachments,
     )
 
     return header, section.content
@@ -154,6 +163,8 @@ def format_draft(header: DraftHeader, body: str) -> str:
         h["source"] = header.source
     if header.time:
         h["time"] = header.time
+    if header.attachments:
+        h["attachments"] = header.attachments
 
     return gaxfile.format_section(h, body)
 
@@ -189,9 +200,31 @@ def get_header(headers_list: list[dict], name: str) -> str:
     return ""
 
 
-def build_message(header: DraftHeader, body: str) -> dict:
-    """Build RFC 2822 message dict for Gmail API."""
-    message = MIMEText(body, "plain", "utf-8")
+def build_message(
+    header: DraftHeader,
+    body: str,
+    attachments: list[tuple[str, str, bytes]] | None = None,
+) -> dict:
+    """Build RFC 2822 message dict for Gmail API.
+
+    Args:
+        header: Draft metadata.
+        body: Plain text body.
+        attachments: Optional list of (filename, mime_type, data) tuples.
+    """
+    if attachments:
+        message = MIMEMultipart()
+        message.attach(MIMEText(body, "plain", "utf-8"))
+        for filename, mime_type, data in attachments:
+            maintype, subtype = mime_type.split("/", 1)
+            part = MIMEBase(maintype, subtype)
+            part.set_payload(data)
+            encoders.encode_base64(part)
+            part.add_header("Content-Disposition", "attachment", filename=filename)
+            message.attach(part)
+    else:
+        message = MIMEText(body, "plain", "utf-8")
+
     message["to"] = header.to
     message["subject"] = header.subject
 
@@ -418,7 +451,10 @@ class Draft(Resource):
             raise ValueError("'subject' field is required")
 
         if not header.draft_id:
-            return f"New draft: {header.subject}\nTo: {header.to}"
+            summary = f"New draft: {header.subject}\nTo: {header.to}"
+            if header.attachments:
+                summary += f"\nAttachments: {', '.join(header.attachments)}"
+            return summary
 
         remote_header, remote_body = fetch_draft(header.draft_id)
 
@@ -430,6 +466,15 @@ class Draft(Resource):
             lines.append(f"subject: {remote_header.subject} -> {header.subject}")
         if header.cc != remote_header.cc:
             lines.append(f"cc: {remote_header.cc} -> {header.cc}")
+
+        local_att_names = set(header.attachments)
+        remote_att_names = set(remote_header.attachments)
+        added = local_att_names - remote_att_names
+        removed = remote_att_names - local_att_names
+        if added:
+            lines.append(f"attachments added: {', '.join(sorted(added))}")
+        if removed:
+            lines.append(f"attachments removed: {', '.join(sorted(removed))}")
 
         body_diff = list(
             difflib.unified_diff(
@@ -456,9 +501,24 @@ class Draft(Resource):
         if not header.subject:
             raise ValueError("'subject' field is required")
 
+        # Resolve attachment paths and read file data
+        resolved_atts: list[tuple[str, str, bytes]] | None = None
+        if header.attachments:
+            resolved_atts = []
+            for att_path in header.attachments:
+                path = Path(att_path)
+                if not path.is_absolute():
+                    path = (self.path.parent / path).resolve()
+                if not path.exists():
+                    raise ValueError(f"Attachment not found: {att_path}")
+                data = path.read_bytes()
+                mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+                resolved_atts.append((path.name, mime_type, data))
+                logger.info(f"Attaching: {path.name} ({len(data)} bytes)")
+
         creds = get_authenticated_credentials()
         service = build("gmail", "v1", credentials=creds)
-        message = build_message(header, body)
+        message = build_message(header, body, resolved_atts)
 
         if not header.draft_id:
             logger.info(f"Creating draft: {header.subject}")

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -9,6 +9,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gax.mail.draft import (
+    DraftHeader,
+    Draft,
+    build_message,
+    parse_draft,
+    format_draft,
+)
 from gax.mail.shared import (
     MailSection,
     pull_thread,
@@ -494,3 +501,187 @@ class TestThreadDiff:
         file.write_text("---\ntype: gax/mail\n---\nno thread id here\n")
         with pytest.raises(ValueError, match="No thread_id"):
             Thread(path=file).diff()
+
+
+# =============================================================================
+# Draft attachment tests
+# =============================================================================
+
+
+class TestDraftAttachments:
+    """Tests for draft attachment support."""
+
+    def test_parse_draft_with_attachments(self):
+        """Attachment paths are parsed from YAML list."""
+        content = (
+            "---\n"
+            "type: gax/draft\n"
+            "subject: Test\n"
+            "to: bob@test.com\n"
+            "attachments:\n"
+            "  - offer.pdf\n"
+            "  - docs/contract.pdf\n"
+            "---\n"
+            "Hello\n"
+        )
+        header, body = parse_draft(content)
+        assert header.attachments == ["offer.pdf", "docs/contract.pdf"]
+        assert "Hello" in body
+
+    def test_parse_draft_without_attachments(self):
+        """Drafts without attachments have empty list."""
+        content = (
+            "---\n"
+            "type: gax/draft\n"
+            "subject: Test\n"
+            "to: bob@test.com\n"
+            "---\n"
+            "Hello\n"
+        )
+        header, _ = parse_draft(content)
+        assert header.attachments == []
+
+    def test_format_draft_with_attachments(self):
+        """Attachments are serialized as YAML list."""
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=["offer.pdf", "contract.pdf"],
+        )
+        content = format_draft(header, "Hello\n")
+        assert "attachments:" in content
+        assert "  - offer.pdf" in content
+        assert "  - contract.pdf" in content
+
+    def test_format_draft_without_attachments(self):
+        """No attachments field when list is empty."""
+        header = DraftHeader(subject="Test", to="bob@test.com")
+        content = format_draft(header, "Hello\n")
+        assert "attachments" not in content
+
+    def test_roundtrip_attachments(self):
+        """Parse then format preserves attachments."""
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=["offer.pdf", "/abs/path/contract.pdf"],
+        )
+        content = format_draft(header, "Body text\n")
+        parsed_header, parsed_body = parse_draft(content)
+        assert parsed_header.attachments == header.attachments
+        assert parsed_header.subject == header.subject
+
+    def test_build_message_without_attachments(self):
+        """Without attachments, produces plain text MIME."""
+        header = DraftHeader(subject="Test", to="bob@test.com")
+        msg = build_message(header, "Hello")
+        assert "raw" in msg
+        import base64
+        raw = base64.urlsafe_b64decode(msg["raw"])
+        assert b"text/plain" in raw
+        assert b"multipart" not in raw
+
+    def test_build_message_with_attachments(self):
+        """With attachments, produces multipart MIME."""
+        header = DraftHeader(subject="Test", to="bob@test.com")
+        attachments = [("report.pdf", "application/pdf", b"fake-pdf-data")]
+        msg = build_message(header, "See attached.", attachments)
+        import base64
+        raw = base64.urlsafe_b64decode(msg["raw"])
+        assert b"multipart" in raw
+        assert b"report.pdf" in raw
+
+    def test_build_message_with_thread_id(self):
+        """Thread ID and reply headers are set."""
+        header = DraftHeader(
+            subject="Re: Test",
+            to="bob@test.com",
+            thread_id="thread-123",
+            in_reply_to="msg-456",
+        )
+        msg = build_message(header, "Reply body")
+        assert msg["threadId"] == "thread-123"
+
+    def test_push_missing_attachment_raises(self, tmp_path):
+        """Push raises ValueError for missing attachment file."""
+        draft_file = tmp_path / "test.draft.gax.md"
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=["nonexistent.pdf"],
+        )
+        draft_file.write_text(format_draft(header, "Hello\n"))
+        with pytest.raises(ValueError, match="Attachment not found"):
+            Draft(path=draft_file).push()
+
+    def test_push_resolves_relative_paths(self, tmp_path, monkeypatch):
+        """Push reads attachment data from paths relative to draft file."""
+        # Create attachment file next to draft
+        att_file = tmp_path / "offer.pdf"
+        att_file.write_bytes(b"pdf-content-here")
+
+        draft_file = tmp_path / "test.draft.gax.md"
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=["offer.pdf"],
+        )
+        draft_file.write_text(format_draft(header, "See attached.\n"))
+
+        # Mock Gmail API
+        mock_service = MagicMock()
+        mock_service.users().drafts().create().execute.return_value = {
+            "id": "draft-123",
+            "message": {"id": "msg-456"},
+        }
+        monkeypatch.setattr("gax.mail.draft.get_authenticated_credentials", lambda: None)
+        monkeypatch.setattr("gax.mail.draft.build", lambda *a, **kw: mock_service)
+
+        Draft(path=draft_file).push()
+
+        # Verify API was called with message containing attachment
+        call_args = mock_service.users().drafts().create.call_args
+        assert call_args is not None
+
+        # Verify draft file was updated with draft_id
+        updated = draft_file.read_text()
+        assert "draft_id: draft-123" in updated
+
+    def test_push_resolves_absolute_paths(self, tmp_path, monkeypatch):
+        """Push reads attachment data from absolute paths."""
+        att_file = tmp_path / "subdir" / "doc.pdf"
+        att_file.parent.mkdir()
+        att_file.write_bytes(b"absolute-pdf")
+
+        draft_file = tmp_path / "test.draft.gax.md"
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=[str(att_file)],
+        )
+        draft_file.write_text(format_draft(header, "Body\n"))
+
+        mock_service = MagicMock()
+        mock_service.users().drafts().create().execute.return_value = {
+            "id": "draft-abs",
+            "message": {"id": "msg-abs"},
+        }
+        monkeypatch.setattr("gax.mail.draft.get_authenticated_credentials", lambda: None)
+        monkeypatch.setattr("gax.mail.draft.build", lambda *a, **kw: mock_service)
+
+        Draft(path=draft_file).push()
+        updated = draft_file.read_text()
+        assert "draft_id: draft-abs" in updated
+
+    def test_diff_new_draft_with_attachments(self, tmp_path):
+        """Diff for new draft shows attachment names."""
+        draft_file = tmp_path / "test.draft.gax.md"
+        header = DraftHeader(
+            subject="Test",
+            to="bob@test.com",
+            attachments=["offer.pdf", "contract.pdf"],
+        )
+        draft_file.write_text(format_draft(header, "Hello\n"))
+
+        result = Draft(path=draft_file).diff()
+        assert "Attachments: offer.pdf, contract.pdf" in result


### PR DESCRIPTION
## Summary

- Add `attachments` field to draft YAML header supporting relative and absolute file paths
- On `gax draft push`, resolve paths, read files, and upload as MIME multipart attachments
- Show attachment info in `gax draft diff` output (new drafts and added/removed attachments)
- 12 new tests covering parse, format, roundtrip, MIME construction, path resolution, and error handling

Closes #2

## Usage

```yaml
---
type: gax/draft
subject: Re: SRE Modul
to: client@example.com
attachments:
  - offer.pdf
  - /absolute/path/to/contract.pdf
---

Email body here...
```

## Test plan

- [x] All 42 tests pass (`pytest tests/test_mail.py`)
- [x] Pre-commit hooks pass (ruff, pytest, trailing whitespace)
- [ ] Manual test: create draft with attachments, push, verify in Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)