### PR TITLE
feat: Granular OAuth scope selection at login

### DIFF
--- a/gax/auth.py
+++ b/gax/auth.py
@@ -10,21 +10,25 @@ CONFIG_DIR = Path.home() / ".config" / "gax"
 CREDENTIALS_FILE = CONFIG_DIR / "credentials.json"
 TOKEN_FILE = CONFIG_DIR / "token.json"
 
-# Scopes needed for Google Sheets, Docs, Slides, Gmail, Calendar, Forms, Contacts, and Drive files
-SCOPES = [
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive",  # read/write/create Drive files
-    "https://www.googleapis.com/auth/documents",  # read/write for import
-    "https://www.googleapis.com/auth/gmail.readonly",
-    "https://www.googleapis.com/auth/gmail.compose",
-    "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/gmail.settings.basic",  # filters
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/tasks",  # read/write tasks
-    "https://www.googleapis.com/auth/forms.body",  # read/write form structure
-    "https://www.googleapis.com/auth/contacts",  # read/write contacts
-    "https://www.googleapis.com/auth/presentations",  # read/write Slides
-]
+SCOPE_PREFIX = "https://www.googleapis.com/auth/"
+
+
+def expand_scopes(short_scopes: list[str]) -> list[str]:
+    """Expand short scope names to full OAuth URLs.
+
+    E.g. "gmail.readonly" -> "https://www.googleapis.com/auth/gmail.readonly"
+    """
+    return [SCOPE_PREFIX + s for s in short_scopes]
+
+
+def get_all_scopes() -> list[str]:
+    """Collect all scopes declared by registered Resource subclasses."""
+    from .resource import Resource
+
+    scopes: set[str] = set()
+    for sub in Resource._subclasses:
+        scopes.update(sub.SCOPES)
+    return sorted(scopes)
 
 # Default OAuth client credentials (public client for CLI apps)
 # Users can replace with their own in ~/.config/gax/credentials.json
@@ -122,8 +126,13 @@ def save_credentials(creds: Credentials) -> None:
         json.dump(token_data, f, indent=2)
 
 
-def login() -> Credentials:
-    """Run OAuth flow and store credentials."""
+def login(scopes: list[str] | None = None) -> Credentials:
+    """Run OAuth flow and store credentials.
+
+    Args:
+        scopes: Short-form scope names to request (e.g. ["gmail.readonly", "calendar"]).
+                If None, requests all scopes from registered resources.
+    """
     if not credentials_exist():
         raise FileNotFoundError(
             f"OAuth credentials not found at {CREDENTIALS_FILE}\n"
@@ -133,9 +142,11 @@ def login() -> Credentials:
             f"  3. Download JSON and save to: {CREDENTIALS_FILE}"
         )
 
+    requested = expand_scopes(scopes or get_all_scopes())
+
     flow = InstalledAppFlow.from_client_secrets_file(
         str(CREDENTIALS_FILE),
-        scopes=SCOPES,
+        scopes=requested,
     )
 
     # Run local server for OAuth callback

--- a/gax/cli.py
+++ b/gax/cli.py
@@ -325,8 +325,14 @@ main.add_command(auth_cmd, name="auth")
 
 
 @auth_cmd.command()
+@click.option(
+    "--scopes",
+    default=None,
+    help="Comma-separated scopes to request (e.g. gmail.readonly,calendar). "
+    "Omit for all scopes. Use 'gax auth scopes' to list available scopes.",
+)
 @handle_errors
-def login():
+def login(scopes):
     """Authenticate with Google (opens browser)."""
     if not auth.credentials_exist():
         click.echo(f"OAuth credentials not found at {auth.CREDENTIALS_FILE}")
@@ -339,8 +345,15 @@ def login():
         click.echo(f"  3. Download JSON and save to: {auth.CREDENTIALS_FILE}")
         sys.exit(1)
 
+    scope_list = [s.strip() for s in scopes.split(",")] if scopes else None
+
+    if scope_list:
+        click.echo(f"Requesting scopes: {', '.join(scope_list)}")
+    else:
+        click.echo("Requesting all scopes.")
+
     click.echo("Opening browser for authentication...")
-    auth.login()
+    auth.login(scopes=scope_list)
     click.echo("Authenticated successfully!")
     click.echo(f"Token saved to: {auth.TOKEN_FILE}")
 
@@ -356,6 +369,23 @@ def status():
     click.echo(f"token_path\t{status['token_path']}")
     click.echo(f"token_exists\t{status['token_exists']}")
     click.echo(f"authenticated\t{status['authenticated']}")
+
+
+@auth_cmd.command()
+def scopes():
+    """List available OAuth scopes grouped by resource."""
+    from .resource import Resource
+
+    seen: set[str] = set()
+    for sub in Resource._subclasses:
+        if not sub.SCOPES:
+            continue
+        scope_str = ", ".join(sub.SCOPES)
+        key = f"{sub.name}:{scope_str}"
+        if key in seen:
+            continue
+        seen.add(key)
+        click.echo(f"{sub.name:15s} {scope_str}")
 
 
 @auth_cmd.command()

--- a/gax/contacts/contacts.py
+++ b/gax/contacts/contacts.py
@@ -562,6 +562,7 @@ class Contact(Resource):
     name = "contact"
     FILE_TYPE = "gax/contact"
     FILE_EXTENSIONS = (".contact.gax.yaml",)
+    SCOPES = ("contacts.readonly",)
 
     def pull(self, **kw) -> None:
         """Pull latest contact data from Google."""
@@ -591,6 +592,7 @@ class Contacts(Resource):
     FILE_TYPE = "gax/contacts"
     FILE_EXTENSIONS = (".contacts.gax.md",)
     CHECKOUT_TYPE = "gax/contacts-checkout"
+    SCOPES = ("contacts",)
 
     def _fetch_and_normalize(self, *, service=None):
         """Fetch contacts from API and normalize. Returns (normalized, groups)."""

--- a/gax/filter/filter.py
+++ b/gax/filter/filter.py
@@ -423,6 +423,7 @@ class Filter(Resource):
 
     name = "filter"
     FILE_TYPE = "gax/filters"
+    SCOPES = ("gmail.settings.basic",)
 
     def clone(self, output: Path | None = None, **kw) -> Path:
         """Clone Gmail filters to a local file."""

--- a/gax/form/form.py
+++ b/gax/form/form.py
@@ -784,6 +784,7 @@ class Form(Resource):
     URL_PATTERN = r"docs\.google\.com/forms/d/"
     FILE_TYPE = "gax/form"
     FILE_EXTENSIONS = (".form.gax.md",)
+    SCOPES = ("forms.body",)
 
     def _output_path(self, title: str, output: Path | None) -> Path:
         if output:

--- a/gax/gcal/gcal.py
+++ b/gax/gcal/gcal.py
@@ -697,6 +697,7 @@ class Cal(Resource):
     name = "cal"
     URL_PATTERN = r"calendar\.google\.com/calendar/"
     FILE_TYPE = "gax/cal-list"
+    SCOPES = ("calendar.readonly",)
 
     def calendars(self, out, **kw) -> None:
         """List available calendars to file descriptor."""
@@ -897,6 +898,7 @@ class Event(Resource):
     FILE_TYPE = "gax/cal"
     FILE_EXTENSIONS = (".cal.gax.md",)
     HAS_GENERIC_DISPATCH = False
+    SCOPES = ("calendar",)
 
     @classmethod
     def from_id(cls, id_value: str) -> "Event":

--- a/gax/gdoc/doc.py
+++ b/gax/gdoc/doc.py
@@ -980,6 +980,7 @@ class Tab(Resource):
     URL_PATTERN = r"docs\.google\.com/document/d/"
     FILE_TYPE = "gax/doc"
     FILE_EXTENSIONS = (".doc.gax.md", ".tab.gax.md")
+    SCOPES = ("documents", "drive.readonly")
 
     def clone(self, output: Path | None = None, **kw) -> Path:
         """Clone a single tab to a .doc.gax.md file.
@@ -1162,6 +1163,7 @@ class Doc(Resource):
     URL_PATTERN = r"docs\.google\.com/document/d/"
     CHECKOUT_TYPE = "gax/doc-checkout"
     HAS_GENERIC_DISPATCH = False
+    SCOPES = ("documents", "drive.readonly")
 
     def clone(self, output: Path | None = None, **kw) -> Path:
         """Clone all tabs into a folder (supports nested tabs)."""

--- a/gax/gdrive/gdrive.py
+++ b/gax/gdrive/gdrive.py
@@ -323,6 +323,7 @@ class File(Resource):
 
     name = "file"
     URL_PATTERN = r"drive\.google\.com/(file/d/|open\?id=)"
+    SCOPES = ("drive",)
 
     @classmethod
     def from_id(cls, id_value: str) -> "File":
@@ -451,6 +452,7 @@ class Folder(Resource):
     name = "folder"
     URL_PATTERN = r"drive\.google\.com/(drive/folders/|folders/)"
     CHECKOUT_TYPE = "gax/drive-checkout"
+    SCOPES = ("drive.readonly",)
 
     @classmethod
     def from_id(cls, id_value: str) -> "Folder":

--- a/gax/gsheet/sheet.py
+++ b/gax/gsheet/sheet.py
@@ -454,6 +454,7 @@ class SheetTab(Resource):
     name = "sheet-tab"
     URL_PATTERN = r"docs\.google\.com/spreadsheets/d/"
     FILE_EXTENSIONS = (".sheet.gax.md",)
+    SCOPES = ("spreadsheets",)
 
     @classmethod
     def from_file(cls, path: Path) -> "SheetTab":
@@ -558,6 +559,7 @@ class Sheet(Resource):
     URL_PATTERN = r"docs\.google\.com/spreadsheets/d/"
     CHECKOUT_TYPE = "gax/sheet-checkout"
     HAS_GENERIC_DISPATCH = False
+    SCOPES = ("spreadsheets",)
 
     def clone(self, output: Path | None = None, **kw) -> Path:
         """Checkout all tabs into a folder.

--- a/gax/gslides/gslides.py
+++ b/gax/gslides/gslides.py
@@ -247,6 +247,7 @@ class Slide(Resource):
     name = "slides"
     FILE_TYPE = "gax/slides"
     FILE_EXTENSIONS = (".slides.gax.md",)
+    SCOPES = ("presentations",)
 
     def pull(self, **kw) -> None:
         """Refresh a single slide file from remote."""
@@ -399,6 +400,7 @@ class Presentation(Resource):
     name = "presentation"
     URL_PATTERN = r"docs\.google\.com/presentation/d/"
     CHECKOUT_TYPE = "gax/slides-checkout"
+    SCOPES = ("presentations",)
 
     def clone(
         self,

--- a/gax/gtask/gtask.py
+++ b/gax/gtask/gtask.py
@@ -492,6 +492,7 @@ class TaskList(Resource):
     FILE_TYPE = "gax/task-list"
     FILE_EXTENSIONS = (".tasks.gax.md", ".tasks.gax.yaml")
     CHECKOUT_TYPE = "gax/task-checkout"
+    SCOPES = ("tasks",)
 
     def lists(self, out) -> None:
         """List available task lists to file descriptor."""
@@ -692,6 +693,7 @@ class Task(Resource):
     name = "task"
     FILE_TYPE = "gax/task"
     FILE_EXTENSIONS = (".task.gax.yaml",)
+    SCOPES = ("tasks",)
 
     def clone(
         self,

--- a/gax/label/label.py
+++ b/gax/label/label.py
@@ -351,6 +351,7 @@ class Label(Resource):
 
     name = "label"
     FILE_TYPE = "gax/labels"
+    SCOPES = ("gmail.labels",)
 
     def clone(
         self,

--- a/gax/mail/draft.py
+++ b/gax/mail/draft.py
@@ -320,6 +320,7 @@ class Draft(Resource):
     URL_PATTERN = r"mail\.google\.com/mail/[^#]*#drafts/"
     FILE_TYPE = "gax/draft"
     FILE_EXTENSIONS = (".draft.gax.md",)
+    SCOPES = ("gmail.readonly", "gmail.compose")
 
     @classmethod
     def from_id(cls, id_value: str) -> "Draft":

--- a/gax/mail/mailbox.py
+++ b/gax/mail/mailbox.py
@@ -409,6 +409,7 @@ class Mailbox(Resource):
 
     name = "mailbox"
     FILE_TYPE = "gax/list"
+    SCOPES = ("gmail.readonly", "gmail.modify")
 
     @classmethod
     def from_file(cls, path: Path) -> "Mailbox":

--- a/gax/mail/thread.py
+++ b/gax/mail/thread.py
@@ -93,6 +93,7 @@ class Thread(Resource):
     name = "thread"
     FILE_TYPE = "gax/mail"
     FILE_EXTENSIONS = (".mail.gax.md",)
+    SCOPES = ("gmail.readonly", "gmail.compose")
 
     @classmethod
     def from_url(cls, url: str) -> "Thread":

--- a/gax/resource.py
+++ b/gax/resource.py
@@ -81,6 +81,11 @@ class Resource:
         FILE_TYPE       — e.g. "gax/doc", matched against YAML type field
         FILE_EXTENSIONS — e.g. (".doc.gax.md", ".tab.gax.md")
         CHECKOUT_TYPE   — e.g. "gax/doc-checkout", matched in .gax.yaml
+
+    Scope metadata (set on subclasses):
+        SCOPES — OAuth scopes needed by this resource (short form,
+                 e.g. "gmail.readonly"). The auth module prepends the
+                 https://www.googleapis.com/auth/ prefix.
     """
 
     name: str
@@ -90,6 +95,8 @@ class Resource:
     FILE_EXTENSIONS: tuple[str, ...] = ()
     CHECKOUT_TYPE: str | None = None
     HAS_GENERIC_DISPATCH: bool = True
+
+    SCOPES: tuple[str, ...] = ()
 
     _subclasses: list[type["Resource"]] = []
 


### PR DESCRIPTION
## Summary

- Each Resource subclass declares its required OAuth scopes via `SCOPES` class attribute (short form like `gmail.readonly`)
- `gax auth login --scopes gmail.readonly,calendar.readonly` requests only specified scopes
- `gax auth scopes` lists all available scopes grouped by resource
- `auth.get_all_scopes()` dynamically collects scopes from registered resources
- No hardcoded scope list — scopes are the union of what resources declare

Closes #49

## Test plan

- [x] All 42 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual: `gax auth scopes` lists resources and their scopes
- [ ] Manual: `gax auth login --scopes calendar.readonly` shows only calendar permission on consent screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)