### PR TITLE
fix: doc table multiline cells, slides images, skipped element logging

### DIFF
--- a/gax/gdoc/ir.py
+++ b/gax/gdoc/ir.py
@@ -301,6 +301,25 @@ def _extract_list_items(list_tok: dict, depth: int = 0) -> list[ListItem]:
     return items
 
 
+def _decode_br_in_spans(spans: list[Span]) -> list[Span]:
+    """Decode <br> tags back to newlines in span text."""
+    result = []
+    for span in spans:
+        if "<br>" in span.text:
+            result.append(
+                Span(
+                    span.text.replace("<br>", "\n"),
+                    bold=span.bold,
+                    italic=span.italic,
+                    strikethrough=span.strikethrough,
+                    url=span.url,
+                )
+            )
+        else:
+            result.append(span)
+    return result
+
+
 def _table_to_rows(tok: dict) -> list[list[list[Span]]]:
     """Convert mistune table token to list of rows of parsed cells."""
     rows: list[list[list[Span]]] = []
@@ -311,7 +330,8 @@ def _table_to_rows(tok: dict) -> list[list[list[Span]]]:
                 cells = []
                 for cell_tok in section_children:
                     if cell_tok["type"] == "table_cell":
-                        cells.append(_flatten_inline(cell_tok.get("children", [])))
+                        spans = _flatten_inline(cell_tok.get("children", []))
+                        cells.append(_decode_br_in_spans(spans))
                 if cells:
                     rows.append(cells)
             else:
@@ -322,7 +342,8 @@ def _table_to_rows(tok: dict) -> list[list[list[Span]]]:
                     for cell_tok in row_tok.get("children", []):
                         if cell_tok["type"] != "table_cell":
                             continue
-                        cells.append(_flatten_inline(cell_tok.get("children", [])))
+                        spans = _flatten_inline(cell_tok.get("children", []))
+                        cells.append(_decode_br_in_spans(spans))
                     rows.append(cells)
     return rows
 
@@ -386,17 +407,28 @@ HEADING_STYLES = {
 HEADING_STYLE_MAP = {v: k for k, v in HEADING_STYLES.items()}
 
 
-def _spans_from_textruns(elements: list[dict]) -> list[Span]:
+def _spans_from_textruns(
+    elements: list[dict], skipped: dict[str, int] | None = None
+) -> list[Span]:
     """Convert Google Docs textRun elements to Span list.
 
     The last element's trailing newline is the paragraph boundary and is
     stripped.  Interior standalone newline runs are hard line breaks and
     are preserved.
+
+    If *skipped* dict is passed, non-textRun element types are counted into it.
     """
     spans: list[Span] = []
     for idx, elem in enumerate(elements):
         tr = elem.get("textRun")
         if not tr:
+            # Track skipped element types
+            elem_type = next(
+                (k for k in elem if k not in ("startIndex", "endIndex")), "unknown"
+            )
+            if skipped is not None:
+                skipped[elem_type] = skipped.get(elem_type, 0) + 1
+            logger.debug("Skipped %s element at index %s", elem_type, elem.get("startIndex", "?"))
             continue
         text = tr["content"]
         is_last = idx == len(elements) - 1
@@ -431,6 +463,7 @@ def from_doc_json(
         lists: The document's lists dict (for determining ordered vs unordered)
     """
     blocks: list[Block] = []
+    skipped: dict[str, int] = {}
 
     for elem in body_content:
         start = elem.get("startIndex", 0)
@@ -449,7 +482,8 @@ def from_doc_json(
                         if "paragraph" in ce:
                             cell_spans.extend(
                                 _spans_from_textruns(
-                                    ce["paragraph"].get("elements", [])
+                                    ce["paragraph"].get("elements", []),
+                                    skipped=skipped,
                                 )
                             )
                     cells.append(cell_spans)
@@ -462,7 +496,7 @@ def from_doc_json(
 
         para = elem["paragraph"]
         elements = para.get("elements", [])
-        spans = _spans_from_textruns(elements)
+        spans = _spans_from_textruns(elements, skipped=skipped)
 
         # Skip empty paragraphs
         if not spans:
@@ -503,6 +537,10 @@ def from_doc_json(
 
         # Regular paragraph
         blocks.append(Paragraph(doc_range=doc_range, spans=spans))
+
+    if skipped:
+        parts = ", ".join(f"{count} {typ}" for typ, count in sorted(skipped.items()))
+        logger.warning(f"Skipped unsupported elements: {parts}")
 
     return blocks
 
@@ -710,7 +748,8 @@ def _render_table(renderer, token, state):
     head_cells = []
     aligns = []
     for cell in head["children"]:
-        head_cells.append(renderer.render_children(cell, state).strip())
+        text = renderer.render_children(cell, state).strip()
+        head_cells.append(text.replace("\n", "<br>"))
         aligns.append(cell.get("attrs", {}).get("align"))
 
     lines = ["| " + " | ".join(head_cells) + " |"]
@@ -729,9 +768,10 @@ def _render_table(renderer, token, state):
 
     if body:
         for row in body["children"]:
-            cells = [
-                renderer.render_children(c, state).strip() for c in row["children"]
-            ]
+            cells = []
+            for c in row["children"]:
+                text = renderer.render_children(c, state).strip()
+                cells.append(text.replace("\n", "<br>"))
             lines.append("| " + " | ".join(cells) + " |")
 
     return "\n".join(lines) + "\n\n"

--- a/gax/gslides/gslides.py
+++ b/gax/gslides/gslides.py
@@ -99,6 +99,13 @@ def _extract_slide_markdown(slide: dict) -> str:
     body_parts = []
 
     for element in slide.get("pageElements", []):
+        # Handle images
+        if "image" in element:
+            url = element["image"].get("contentUrl", "")
+            if url:
+                body_parts.append(f"![image]({url})")
+            continue
+
         shape = element.get("shape")
         if not shape:
             continue

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -598,3 +598,109 @@ def _find_cell(table, cell_text):
     raise AssertionError(
         f"Cell {cell_text!r} not found in table"
     )
+
+
+# =============================================================================
+# Test 4: Inline images and unsupported elements
+# =============================================================================
+
+# A small 1x1 red PNG for testing (publicly accessible)
+TEST_IMAGE_URL = "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
+
+
+@pytest.mark.e2e
+class TestInlineElements:
+    """Insert inline images via API, pull, verify they appear in markdown."""
+
+    @pytest.fixture(scope="class")
+    def tab_with_image(self, doc_id, services):
+        """Create a tab, insert text + inline image via API."""
+        tab_name = _unique("rt_img")
+        docs = services["docs"]
+
+        # Step 1: Create tab with initial text
+        tab_id, _ = create_tab_with_content(
+            doc_id,
+            tab_name,
+            "# Image Test\n\nBefore image.\n\nAfter image.\n",
+            service=docs,
+            num_retries=NUM_RETRIES,
+        )
+
+        # Step 2: Re-read to find insertion point (after "Before image.\n")
+        doc = docs.documents().get(
+            documentId=doc_id, includeTabsContent=True
+        ).execute(num_retries=NUM_RETRIES)
+
+        body = _get_tab_body(doc, tab_id)
+        insert_index = None
+        for elem in body:
+            if "paragraph" in elem:
+                for e in elem["paragraph"].get("elements", []):
+                    tr = e.get("textRun", {})
+                    if "Before image." in tr.get("content", ""):
+                        insert_index = e["endIndex"]
+
+        assert insert_index is not None, "Could not find insertion point"
+
+        # Step 3: Insert inline image
+        docs.documents().batchUpdate(
+            documentId=doc_id,
+            body={
+                "requests": [
+                    {
+                        "insertInlineImage": {
+                            "uri": TEST_IMAGE_URL,
+                            "location": {
+                                "index": insert_index,
+                                "tabId": tab_id,
+                            },
+                            "objectSize": {
+                                "width": {"magnitude": 100, "unit": "PT"},
+                                "height": {"magnitude": 34, "unit": "PT"},
+                            },
+                        }
+                    }
+                ]
+            },
+        ).execute(num_retries=NUM_RETRIES)
+
+        return tab_name, tab_id
+
+    def test_pull_contains_image_or_warning(self, doc_id, tab_with_image):
+        """Pull tab with inline image — should either render it or warn."""
+        import logging
+
+        tab_name, tab_id = tab_with_image
+
+        # Capture warnings from the pull
+        warnings = []
+        handler = logging.Handler()
+        handler.emit = lambda record: warnings.append(record.getMessage())
+        handler.setLevel(logging.WARNING)
+        ir_logger = logging.getLogger("gax.gdoc.ir")
+        ir_logger.addHandler(handler)
+
+        try:
+            source_url = f"https://docs.google.com/document/d/{doc_id}/edit"
+            section = pull_single_tab(doc_id, tab_name, source_url)
+        finally:
+            ir_logger.removeHandler(handler)
+
+        md = section.content
+
+        # The image should either appear as ![image](...) in markdown
+        # or be logged as a skipped inlineObjectElement
+        has_image_md = "![" in md
+        has_skip_warning = any("inlineObjectElement" in w for w in warnings)
+
+        assert has_image_md or has_skip_warning, (
+            f"Expected inline image in markdown or skip warning.\n"
+            f"Markdown:\n{md}\n"
+            f"Warnings: {warnings}"
+        )
+
+        # Verify the rest of the content is intact
+        assert "Image Test" in md
+        assert "Before image." in md
+        assert "After image." in md


### PR DESCRIPTION
## Summary

- **Doc tables**: multiline cells broke markdown table rows (same `<br>` encoding fix as sheets in 070798d)
- **Slides images**: clone now extracts `image` elements as `![image](contentUrl)` instead of silently skipping them  
- **Skipped element logging**: `from_doc_json` now logs `debug` for each skipped non-textRun element (inlineObjectElement, richLink, person) and emits a `warning` summary with counts (e.g. "Skipped unsupported elements: 2 person, 1 inlineObjectElement")

## Test plan

- [x] All 450 non-e2e tests pass
- [x] Doc table `<br>` roundtrip verified manually
- [x] Slides clone verified against real presentation (images now appear)
- [ ] Verify skipped element warning appears on pull of doc with @mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)